### PR TITLE
Check samplesheet fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Initial release of nf-core/taxtriage, created with the [nf-core](https://nf-co.r
 
 ### `Fixed`
 
+check_samplesheet.py would compare all the suffixes after the initial "." which would result in an error if samples have discrepancies after the initial ".". Solutoin was to compare only the last 2 suffixes that always should be ".fastq" and ".gz".
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -120,7 +120,7 @@ class RowChecker:
         if row[self._first_col] and row[self._second_col]:
             row[self._single_col] = False
             assert (
-                Path(row[self._first_col]).suffixes == Path(row[self._second_col]).suffixes
+                Path(row[self._first_col]).suffixes[-2:] == Path(row[self._second_col]).suffixes[-2:]
             ), "FASTQ pairs must have the same file extensions."
         else:
             row[self._single_col] = True


### PR DESCRIPTION
Check_samplesheet.py may not be able to handle certain file names.

Within the script, _validate_pair function checks user's samples sheet and confirms that both .fastq.gz paired files have matching extensions using pathlib’s Path and .suffixes. .suffixes separates the filename by “.” and removes the first iteration while considering the rest as suffixes. In case sample name has multiple “.” delimiters – the suffixes of paired reads will not match.

For example, downsample.<samplename>.fastq.gz will not be taken by the pipeline as script will consider [.’<samplename>’, ‘fastq’, ‘.gz’] as suffixes and when it will compare the suffixes, <samplename> will not match on paired files due to differences in their naming resulting in the error “FASTQ pairs must have the same file extensions.” subsequently aborting the pipeline. 

Solution: In check_samplesheet.py, on line 123 change as following:
`Path(row[self._first_col]).suffixes[-2:] == Path(row[self._second_col]).suffixes[-2:]`

This will select and compare only the last two suffixes which always should be the same: “.fastq” and “.gz”. This will allow a much greater flexibility in naming of samples. The fix was tested on multiple sample-sheets with success. 

`CHANGELOG.md` is updated to include the explanation of the change. 