### PR TITLE
Added a RANDOM variable to tmp folder in sam_to_confidence.sh to prevent crash.

### DIFF
--- a/bin/sam_to_confidence.sh
+++ b/bin/sam_to_confidence.sh
@@ -86,7 +86,7 @@ absolute_path_x="$(readlink -fn -- "$0"; echo x)"
 absolute_path_of_script="${absolute_path_x%x}"
 scriptdir=$(dirname "$absolute_path_of_script")
 runtime=$(date +"%Y%m%d%H%M%S%N")
-tmp="$scriptdir/tmp-$runtime"
+tmp="$scriptdir/tmp-$runtime-$RANDOM"
 mkdir -p "$tmp"
 #	MAIN
 


### PR DESCRIPTION
This PR suggest to add a RANDOM variable to the sam_to_confidence.sh to prevent the crash resulting from multiple jobs coming off the SGE queue at the same time. Without this fix, I am unable to run the TaxTriage on our HPC without a crash. 

Adding a Random 5 digit variable practically removes the chances of two folders being created with the same nomenclature. The solution has been tested multiple times and eliminated such errors since the implementation.

Below is the nextflow error output that results from the issue described above that is fixed by this adding a RANDOM variable:

> 
> ``Error executing process > 'NFCORE_TAXTRIAGE:TAXTRIAGE:CONFIDENCE_METRIC (Sample_6_DNA)'
> 
> Caused by:
>   Process `NFCORE_TAXTRIAGE:TAXTRIAGE:CONFIDENCE_METRIC (Sample_6_DNA)` terminated with an error exit status (1)
> 
> Command executed:
> 
>   sam_to_confidence.sh \
>       -i Sample_6_DNA.sam \
>       -m Sample_6_DNA.mpileup \
>       -o Sample_6_DNA.confidences.tsv \
>       -r Sample_6_DNA.reads
>   
>   cat <<-END_VERSIONS > versions.yml
>   "NFCORE_TAXTRIAGE:TAXTRIAGE:CONFIDENCE_METRIC":
>       awk: $(awk --version )
>   END_VERSIONS
> 
> Command exit status:
>   1
> 
> Command output:
>   READS to be output in a 2 column file to Sample_6_DNA.reads
>   adding reads to Sample_6_DNA.reads as 2 column file
>   added reads to necessary file
>   ______
> 
> Command error:
>   finding best single alignment per read
>   awk: fatal: cannot open file `/scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/tmp1_included.sam' for reading (No such file or directory)
>   cut: /scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/tmp1_included.sam: No such file or directory
>      single best alignments
>     to 0 unique accessions
>   finding reads with a [block length]:[read length] ratio > 0.80
>   /scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/sam_to_confidence.sh: line 141: /scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/tmp2.sam: No such file or directory
>   /scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/sam_to_confidence.sh: line 145: /scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/uniq.refs: No such file or directory
>   awk: fatal: cannot open file `/scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/tmp1_included.sam' for reading (No such file or directory)
>   cut: /scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/tmp2.sam: No such file or directory
>   awk: fatal: cannot open file `/scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/uniq.refs' for reading (No such file or directory)
>   awk: fatal: cannot open file `/scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/uniq.refs' for reading (No such file or directory)
>      uniquely mapping reads
>     to  accessions
>   gathering alignment stats
>   gawk: cmd. line:7: fatal: cannot open file `/scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N/tmp2.sam' for reading (No such file or directory)
>   rm: can't remove '/scicomp/home-pure/ukm9/.nextflow/assets/jhuapl-bio/taxtriage/bin/tmp-20230810150346%N': No such file or directory
> 
> Work dir:
>   /scicomp/groups/OID/NCEZID/DSR/BCFB/by-project/ukm9_TaxTriage/taxtriage/work/13/f460200d3a4812c327538ece9614e4
> 
> Tip: you can try to figure out what's wrong by changing to the process work dir and showing the script file named `.command.sh`
> 