### PR TITLE
changed singularity container to include wget https support

### DIFF
--- a/modules/local/download_taxtab.nf
+++ b/modules/local/download_taxtab.nf
@@ -20,7 +20,7 @@ process DOWNLOAD_TAXTAB {
 
     conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gawk:4.2.0' :
+        'https://depot.galaxyproject.org/singularity/gnu-wget%3A1.18--h7132678_6' :
         'gcc:bullseye' }"
 
     output:


### PR DESCRIPTION
Container that is being used in the _download_taxtab.nf_ step uses older version of _wget_ that doesn't support _https_ resulting in error which aborts the pipeline. Changing the container to the one used in _get_assembly_refs.nf_ fixes the issue. 

Error information below:
> Error executing process > 'NFCORE_TAXTRIAGE:TAXTRIAGE:DOWNLOAD_TAXTAB'
>
>Caused by:
> Process `NFCORE_TAXTRIAGE:TAXTRIAGE:DOWNLOAD_TAXTAB` terminated with an error exit status (1)
>
>Command executed:
>
>  wget https://github.com/jhuapl-bio/datasets/raw/main/databases/ncbi/taxonomy.tab.gz -O taxonomy.tab.gz && gzip -d >taxonomy.tab.gz
>
>Command exit status:
>  1
>
>Command output:
>  (empty)
>
> 
> Command error:
>   WARNING: Skipping mount /var/singularity/mnt/session/etc/resolv.conf [files]: /etc/resolv.conf doesn't exist in container
>   wget: not an http or ftp url: https://github.com/jhuapl-bio/datasets/raw/main/databases/ncbi/taxonomy.tab.gz
> 
> Work dir:
>   /scratch/72/022a2192978678f70ecad85676f995
> 
> Tip: you can try to figure out what's wrong by changing to the process work dir and showing the script file named `.command.sh`
> 