### PR TITLE
Separate accession cols and create reports by rank

### DIFF
--- a/bin/filter_tsv.py
+++ b/bin/filter_tsv.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse 
+import os 
+import csv
+
+parser = argparse.ArgumentParser(description='Filter merged tsv file by taxonomic rank')
+parser.add_argument('--input', '-i', type=str,  nargs='+', required=True, help='Input merged tsv file')
+parser.add_argument('--output', '-o', type=str, required=True, help='Output TSV files')
+
+# Parse the arguments
+args = parser.parse_args()
+
+
+def filter_tsv(filepath):
+    # Define the classes and ranks
+    omit = {'U', 'D', 'S1', 'S2', 'K'}
+    rank_to_dict = {'P': 'phylum', 'C': 'class', 'O': 'order', 'F': 'family', 'G': 'genus', 'S': 'species'}
+
+    # Read the TSV file line by line and create filtered files
+    with open(filepath, 'r') as input_file:
+        reader = csv.DictReader(input_file, delimiter='\t')
+        
+        for row in reader:
+            rank = row['rank']
+            
+            if rank not in omit:
+                class_name = rank_to_dict.get(rank)
+                if class_name:
+                    output_file_path = f"{class_name}_filtered_mqc.tsv"
+                    
+                    # Create a new dictionary without the 'rank' column
+                    filtered_row = {key: value for key, value in row.items() if key != 'rank'}
+                    
+                    with open(output_file_path, 'a') as output_file:
+                        writer = csv.DictWriter(output_file, fieldnames=filtered_row.keys(), delimiter='\t')
+                        
+                        if output_file.tell() == 0:
+                            writer.writeheader()
+                        
+                        writer.writerow(filtered_row)
+
+
+if __name__ == "__main__":
+    print(args.input)
+    filter_tsv(args.input[0])

--- a/bin/mergeConfidence.py
+++ b/bin/mergeConfidence.py
@@ -88,20 +88,38 @@ def import_file(tsv_filename, kraken_report, samplename, format_kraken2):
     tsv_file = open(tsv_filename)
     rows = dict()
     confidence_tsv = csv.reader(tsv_file, delimiter="\t")
+
+    index_id = 0
     for row in confidence_tsv:
+        
         splitrow = row[0].split("|")
         ref = splitrow[3]
         taxid = splitrow[1]
         if format_kraken2:
             row[0] = taxid
+
         if taxid not in rows:
             rows[taxid] = [row]
+            row.insert(0, index_id)
+            if samplename:
+                row.insert(2, samplename)
+                row.insert(3, ref)
+            else:
+                row.insert(2, "N/A")
+                row.insert(3, ref)
+            index_id += 1
+
         else:
+            row.insert(0, index_id)
+            if samplename:
+                row.insert(2, samplename)
+                row.insert(3, ref)
+            else:
+                row.insert(2, "N/A")
+                row.insert(3, ref)
             rows[taxid].append(row)
+            index_id += 1
         
-        if samplename:
-            row[0] = row[0] +"_" + samplename + "_" + ref
-            # row[0] = row[0] +"_" + samplename  
     tsv_file.close()
     report_file = open(kraken_report)
     report = csv.reader(report_file, delimiter="\t")
@@ -111,7 +129,7 @@ def import_file(tsv_filename, kraken_report, samplename, format_kraken2):
         name = row[5].strip()
         if taxid in rows:
             for i in range(0, len(rows[taxid])):
-                rows[taxid][i].insert(1,rank)   
+                rows[taxid][i].insert(4,rank)   
                 rows[taxid][i].append(name)
     # filter rows where no taxid or name
     
@@ -130,7 +148,8 @@ def main(argv=None):
     path  = open(args.file_out, "w")
     writer = csv.writer(path, delimiter='\t')
     # header = ['Acc', 'Name', 'Rank', 'Length', 'Reads Aligned', 'Abu Total Aligned', 'Abu Total Bases', 'Total Bases Adjusted', 'Breadth Genome Coverage', 'Depth Coverage Mean', 'Depth Coverage Stdev', 'Depth Coef. Variation']
-    header = ["Acc", "Rank", "Mean Depth", "Avg Cov.", "Ref. Size",  "Reads Aligned", "% Aligned", "Stdev", "Abu Aligned", "1:10:50:100:300X", "Name"]
+    #header = ["Acc", "Rank", "Mean Depth", "Avg Cov.", "Ref. Size",  "Reads Aligned", "% Aligned", "Stdev", "Abu Aligned", "1:10:50:100:300X", "Name"]
+    header = ["Index", "Tax_Id", "Sample_Name", "Reference", "Rank", "Mean Depth", "Avg Cov.", "Ref. Size",  "Reads Aligned", "% Aligned", "Stdev", "Abu Aligned", "1:10:50:100:300X", "Name"]
     writer.writerow(header)
     if len(rows.keys()) == 0:
         empty = ['None']

--- a/modules/local/filter_krakenreport.nf
+++ b/modules/local/filter_krakenreport.nf
@@ -1,0 +1,39 @@
+process FILTERKRAKEN {
+    label 'process_medium'
+
+    /* conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/biopython:1.78' :
+        'pegi3s/biopython:latest' }" */
+
+    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.9--1' :
+        'quay.io/biocontainers/python:3.8.3' }"
+        
+        
+    input:
+    path krakenreport 
+
+    output:
+    path("*_filtered_mqc.tsv"), optional:true, emit: reports
+    /* path("species_filtered.tsv"), optional:true, emit: speciesreport
+    path("genus_filtered.tsv"), optional:true, emit: genusreport
+    path("family_filtered.tsv"), optional:true, emit: familyreport
+    path("order_filtered.tsv"), optional:true, emit: orderreport
+    path("class_filtered.tsv"), optional:true, emit: classreport
+    path("phylum_filtered.tsv"), optional:true, emit: phylumreport */
+
+    script:
+
+    """
+    filter_tsv.py \\
+        -o ./ \\
+        -i $krakenreport
+    
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":  
+        python3: \$(python3 --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/modules/local/top_hits.nf
+++ b/modules/local/top_hits.nf
@@ -50,7 +50,7 @@ process TOP_HITS {
         $top_hits_count  $top_per_taxa
     
     awk -F '\\t' -v id=${id} \\
-        'BEGIN{OFS=\"\\t\"} { if (NR==1){ print \"Sample_Taxid\",  \$1, \$4, \$6} else { \$5 = id\"_\"\$5;  print \$5, \$1, \$4, \$6  }}'  ${id}.top_report.tsv > ${id}.krakenreport_mqc.tsv 
+        'BEGIN{OFS=\"\\t\"} { if (NR==1){ print \"Sample_Taxid\", \$2, \$1, \$4, \$6} else { \$5 = id\"_\"\$5;  print \$5, \$2, \$1, \$4, \$6  }}'  ${id}.top_report.tsv > ${id}.krakenreport_mqc.tsv 
     
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Changes made to create distinct MultiQC kraken output tables based on taxonomy (species, phylum, etc..). Added more descriptive columns in place of the accession column for the output confidence table.
