### PR TITLE
nextflow.config update to include h_vmem parameter in sge process.clusterOptions

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -210,6 +210,7 @@ profiles {
     }
     sge {
         process.executor = 'sge'
+        process.clusterOptions = { "-l h_vmem=${task.memory.toMega()}M" }
     }
     arm {
         docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'


### PR DESCRIPTION
SGE clusters, memory requests are specified with the `h_vmem` variable, rather than the Nextflow default virtual_free. `process.clusterOptions` variable has been added to the nextflow.config in order to avoid the default allocation which caused issues in high memory processes (such as Kraken2). 

Adds line to the .command.run, in which value is provided by `task.memory.toMega()`
`#$ -l h_vmem=<VALUE>M`

Commit was tested by fresh clone of the main branch and a TaxTriage run. 