### PR TITLE
IndexError and scientific notation fix in match_paths.py.

### DIFF
--- a/bin/match_paths.py
+++ b/bin/match_paths.py
@@ -2206,6 +2206,8 @@ def main():
 
 
 def format_non_zero_decimals(number):
+    # Convert number from the scientific notation to the tenth digit
+    number = "{:.10f}".format(number).rstrip('0').rstrip('.')
     # Convert the number to a string
     num_str = str(number)
     if '.' not in num_str:

--- a/bin/match_paths.py
+++ b/bin/match_paths.py
@@ -2000,7 +2000,7 @@ def main():
             # Get the index of the value
             try:
                 idx = [x[1] for x in sibling_k2_reads_total].index(value['taxids'][0])
-            except ValueError:
+            except (ValueError, IndexError):
                 # If value['taxids'][0] is not found, handle it appropriately
                 idx = -1
 


### PR DESCRIPTION
Introducing two reproducible error fixes for `match_paths.py`: `IndexError` catch  and numbers scientific notation numbers in `format_non_zero_decimals` function. More on each error and fix in detail below:

**Issue 1:** Catching IndexError when evaluating `idx` using empty `value['taxids'][0]`.

In `match_paths.py` when the value['taxids'][0] is empty, getting a Python IndexError below. 

```
Traceback (most recent call last):
  File "<...>/taxtriage/bin/match_paths.py", line 2697, in <module>
    sys.exit(main())
             ^^^^^^
  File "<...>/taxtriage/bin/match_paths.py", line 2002, in main
    idx = [x[1] for x in sibling_k2_reads_total].index(value['taxids'][0])
                                                       ~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```
**Solution**
The exception in line 2003 of `match_paths.py` only catches the ValueError, so IndexError was added so `except (ValueError, IndexError):`

**Issue 2:** When scientific notation numbers are being fed to the `format_non_zero_decimals` function it throws an error:

```
Traceback (most recent call last):
  File "<...>/taxtriage/bin/match_paths.py", line 2697, in <module>
    sys.exit(main())
             ^^^^^^
  File "<...>/taxtriage/bin/match_paths.py", line 2116, in main
    final_scores = calculate_scores(
                   ^^^^^^^^^^^^^^^^^
  File "<...>/taxtriage/bin/match_paths.py", line 2558, in calculate_scores
    percent_total = format_non_zero_decimals(100*countreads / total_reads)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<...>/taxtriage/bin/match_paths.py", line 2223, in format_non_zero_decimals
    return str(float(formatted_number))
               ^^^^^^^^^^^^^^^^^^^^^^^
ValueError: could not convert string to float: '6.5e' 

```
**Solution**
Had to add a conversion of a number in scientific notation to produce a string of non-scientific notation up to the 9th decimal: `number = "{:.10f}".format(number).rstrip('0').rstrip('.')` 