### PR TITLE
154 minimap2 alignment memory allocation leads to oom error

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -97,7 +97,7 @@ process {
         ext.prefix = { "${meta.id}.consensus" }
     }
     withName: ALIGNMENT_PER_SAMPLE {
-        errorStrategy = { task.exitStatus in ['143','137','104','134','139','1'] ? 'retry' : 'ignore' }
+        errorStrategy = { task.exitStatus in [143, 137, 104, 134, 139, 1] ? 'retry' : 'ignore' }
         memory = { check_max(72.GB * task.attempt * 2, 'memory') }
         maxRetries = 2
     }
@@ -122,7 +122,7 @@ process {
         errorStrategy = 'ignore'
     }
     withName: DIAMOND_BLASTX {
-        errorStrategy = { task.exitStatus in ['143','137','104','134','139','1'] ? 'retry' : 'ignore' }
+        errorStrategy = { task.exitStatus in [143, 137, 104, 134, 139, 1] ? 'retry' : 'ignore' }
         memory = { check_max(72.GB * task.attempt * 2, 'memory') }
         maxRetries = 2
         ext.args = '--very-sensitive'
@@ -146,7 +146,7 @@ process {
         ext.args = ''
         memory = { check_max(36.GB * task.attempt * 2, 'memory') } // Starts with GB and doubles each attempt
         maxRetries = 2
-        errorStrategy = { task.exitStatus in ['143','137','104','134','139','1'] ? 'retry' : 'ignore' }
+        errorStrategy = { task.exitStatus in [143, 137, 104, 134, 139, 1] ? 'retry' : 'ignore' }
     }
     withName: FEATURES_DOWNLOAD {
         errorStrategy = 'ignore'
@@ -158,12 +158,12 @@ process {
         errorStrategy = 'ignore'
     }
     withName: BEDTOOLS_GENOMECOVERAGE {
-        errorStrategy = { task.exitStatus in ['143','137','104','134','139','1'] ? 'retry' : 'ignore' }
+        errorStrategy = { task.exitStatus in [143, 137, 104, 134, 139, 1] ? 'retry' : 'ignore' }
         memory = { check_max(36.GB * task.attempt * 2, 'memory') }
         maxRetries = 3
     }
     withName: BEDTOOLS_COVERAGE  {
-        errorStrategy = { task.exitStatus in ['143','137','104','134','139','1'] ? 'retry' : 'ignore' }
+        errorStrategy = { task.exitStatus in [143, 137, 104, 134, 139, 1] ? 'retry' : 'ignore' }
         memory = { check_max(36.GB * task.attempt * 2, 'memory') }
         maxRetries = 3
         publishDir = [path:{ "${params.outdir}/alignment" }, mode:'copy', saveAs:{ filename -> filename.equals('versions.yml') ? null : filename }]
@@ -210,7 +210,7 @@ process {
         }
     }
     withName: REMOVE_HOSTREADS {
-        errorStrategy  = { task.exitStatus in ['143','137','104','134','139','1'] ? 'retry' : 'ignore' }
+        errorStrategy  = { task.exitStatus in [143, 137, 104, 134, 139, 1] ? 'retry' : 'ignore' }
         maxRetries     = 1
     }
 

--- a/modules/nf-core/minimap2/align/main.nf
+++ b/modules/nf-core/minimap2/align/main.nf
@@ -38,7 +38,7 @@ process MINIMAP2_ALIGN {
     def cpu_limit = task.cpus > 1 ? (task.cpus / 2).round().toInteger() : 1
 
     // def minmapq = minmapq ? " -q ${minmapq} " :  ""
-    def I_value = "${(task.memory.toMega() * Math.min(0.7 / task.cpus, 0.7)).longValue()}M"
+    def I_value = "${(task.memory.toMega() * Math.min(0.6 / task.cpus, 0.6)).longValue()}M"
     def S_value = "${(task.memory.toMega() * Math.min(0.10 / task.cpus, 0.10)).longValue()}M"
     def bam_output = bam_format ? "-a | samtools sort -@ ${cpu_limit} -m $S_value | samtools view -@ ${cpu_limit} -b -h -o ${prefix}.bam" : "-o ${prefix}.paf"
     def cigar_paf = cigar_paf_format && !bam_format ? "-c" : ''


### PR DESCRIPTION
- Dropping ram use for mmap2 to 60% in container
- Update retry strategy as integers in modules.config rather than strings