### PR TITLE
adding ncbi fallback restoration and mapfile

### DIFF
--- a/bin/append_taxid.py
+++ b/bin/append_taxid.py
@@ -20,6 +20,13 @@ import argparse
 import pandas as pd
 from pathlib import Path
 
+try:
+    # Shared stdlib-only helper (bin/ncbi_taxid.py). Available alongside this
+    # script in the staged bin/ directory at runtime.
+    from ncbi_taxid import fetch_taxid
+except Exception:  # noqa: BLE001 - keep working even if helper is unavailable
+    fetch_taxid = None
+
 def parse_args(argv=None):
     """Define and immediately parse command line arguments."""
     parser = argparse.ArgumentParser(
@@ -60,6 +67,49 @@ def parse_args(argv=None):
         default="taxid",
         help="Column name in the reference file to map to (e.g., taxid, species_taxid)",
     )
+    parser.add_argument(
+        "-b",
+        "--ncbi-backup",
+        dest="ncbi_backup",
+        action="store_true",
+        default=False,
+        help=(
+            "For accessions with no GCF/GCA -> taxid match in the reference "
+            "assembly summaries, query NCBI E-utilities by accession to recover "
+            "the taxid and write it into the map file."
+        ),
+    )
+    parser.add_argument(
+        "-e",
+        "--email",
+        metavar="EMAIL",
+        type=str,
+        required=False,
+        default=None,
+        help="Email for NCBI E-utilities querying (used with --ncbi-backup).",
+    )
+    parser.add_argument(
+        "--api-key",
+        dest="api_key",
+        metavar="API_KEY",
+        type=str,
+        required=False,
+        default=None,
+        help="Optional NCBI API key for E-utilities querying.",
+    )
+    parser.add_argument(
+        "--custom-map",
+        dest="custom_map",
+        metavar="CUSTOM_MAP",
+        type=Path,
+        required=False,
+        default=None,
+        help=(
+            "TSV file with columns 'accession' and 'taxid' for manually mapping "
+            "non-standard accessions absent from assembly summaries and NCBI. "
+            "The 'accession' column must match the Acc (nuccore accession) in the input."
+        ),
+    )
     return parser.parse_args(argv)
 
 def read_input_file(input_file):
@@ -69,14 +119,118 @@ def read_reference_file(ref_file):
     # skip the first line for ref_file
     return pd.read_csv(ref_file, sep='\t', skiprows=1)
 
+def _clean_taxid(value):
+    """Render a taxid as a clean string ('2697049' not '2697049.0', '' for NaN)."""
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if text == "" or text.lower() == "nan":
+        return ""
+    # pandas may coerce integer taxids to float (e.g. 2697049.0) when the
+    # column contains NaNs; strip the spurious trailing decimal.
+    if text.endswith(".0"):
+        text = text[:-2]
+    return text
+
+
 def map_gcf_to_taxid(input_df, ref_df, column):
     # Create a dictionary from the reference file for mapping
     gcf_to_taxid = ref_df.set_index('#assembly_accession')[column].to_dict()
 
-    # Map the GCF to the desired column (taxid or specified column)
-    input_df['Mapped_Value'] = input_df['Assembly'].map(gcf_to_taxid)
+    # Map the GCF to the desired column (taxid or specified column), keeping the
+    # result as clean object-typed strings so NaNs don't coerce taxids to float
+    # and so the NCBI backup can assign string taxids without dtype conflicts.
+    input_df['Mapped_Value'] = input_df['Assembly'].map(gcf_to_taxid).apply(_clean_taxid).astype(object)
 
     return input_df
+
+def apply_custom_map(mapped_df, custom_map_file):
+    """Apply a user-supplied accession->taxid mapping for non-standard accessions.
+
+    Reads a TSV with columns 'accession' and 'taxid'. For any row where
+    Mapped_Value is still empty AND the Acc appears in the custom map, fills in
+    the taxid. Rows already resolved by the assembly summary lookup are untouched.
+
+    Expected file format (tab-separated, with header):
+        accession\\ttaxid
+        OR833055.1\\t2697049
+        CUSTOM_SEQ_001\\t12345
+    """
+    try:
+        custom_df = pd.read_csv(custom_map_file, sep='\t', dtype=str)
+    except Exception as e:
+        print(f"WARNING: Could not read custom map file '{custom_map_file}': {e}. Skipping.")
+        return mapped_df
+
+    required_cols = {"accession", "taxid"}
+    missing_cols = required_cols - set(custom_df.columns.str.lower())
+    if missing_cols:
+        print(
+            f"WARNING: Custom map file is missing required column(s): {missing_cols}. "
+            "Expected a TSV with headers 'accession' and 'taxid'. Skipping."
+        )
+        return mapped_df
+
+    custom_df.columns = custom_df.columns.str.lower()
+    custom_lookup = custom_df.set_index("accession")["taxid"].apply(_clean_taxid).to_dict()
+
+    def _is_missing(value):
+        if value is None:
+            return True
+        text = str(value).strip()
+        return text == "" or text.lower() == "nan"
+
+    missing_mask = mapped_df["Mapped_Value"].apply(_is_missing)
+    resolved = 0
+    for idx in mapped_df.index[missing_mask]:
+        acc = str(mapped_df.at[idx, "Acc"]).strip()
+        if acc in custom_lookup and custom_lookup[acc]:
+            mapped_df.at[idx, "Mapped_Value"] = custom_lookup[acc]
+            resolved += 1
+
+    print(f"Custom map resolved {resolved} of {int(missing_mask.sum())} unmapped accession(s).")
+    return mapped_df
+
+
+def backfill_missing_taxids(mapped_df, email=None, api_key=None):
+    """Fill empty Mapped_Value taxids by querying NCBI per accession.
+
+    Accessions that were not present in any assembly summary (e.g. a local
+    reference FASTA such as OR833055.1) have no GCF -> taxid mapping, leaving
+    Mapped_Value blank. Query NCBI directly by the nuccore accession (the 'Acc'
+    column) to recover the taxid so it can be passed downstream in the map file.
+    """
+    if fetch_taxid is None:
+        print("NCBI backup requested but ncbi_taxid helper is unavailable; skipping.")
+        return mapped_df
+
+    def _is_missing(value):
+        if value is None:
+            return True
+        text = str(value).strip()
+        return text == "" or text.lower() == "nan"
+
+    missing_mask = mapped_df["Mapped_Value"].apply(_is_missing)
+    n_missing = int(missing_mask.sum())
+    if n_missing == 0:
+        return mapped_df
+
+    print(f"Attempting NCBI taxid backup lookup for {n_missing} unmapped accession(s)...")
+    cache = {}
+    resolved = 0
+    for idx in mapped_df.index[missing_mask]:
+        acc = str(mapped_df.at[idx, "Acc"]).strip()
+        if not acc or acc.lower() == "nan":
+            continue
+        if acc not in cache:
+            cache[acc] = fetch_taxid(acc, email=email, api_key=api_key)
+        taxid = cache[acc]
+        if taxid:
+            mapped_df.at[idx, "Mapped_Value"] = taxid
+            resolved += 1
+    print(f"NCBI taxid backup resolved {resolved} of {n_missing} accession(s).")
+    return mapped_df
+
 
 def main(argv=None):
     args = parse_args(argv)
@@ -85,6 +239,10 @@ def main(argv=None):
     ref_df = pd.concat([read_reference_file(f) for f in args.ref_file], ignore_index=True)
 
     mapped_df = map_gcf_to_taxid(input_df, ref_df, args.column)
+    if args.custom_map:
+        mapped_df = apply_custom_map(mapped_df, args.custom_map)
+    if args.ncbi_backup:
+        mapped_df = backfill_missing_taxids(mapped_df, email=args.email, api_key=args.api_key)
     # Write the output to the specified file
     if args.output:
         mapped_df[['Acc', 'Assembly',  'Organism_Name', 'Description', 'Mapped_Value']].to_csv(args.output, sep='\t', index=False)

--- a/bin/fuzzy_match_assembly.py
+++ b/bin/fuzzy_match_assembly.py
@@ -163,9 +163,17 @@ def main():
                         if gcf:
                             final_list.append(f"{seq_record.id}\t{gcf}\t{basename}\t{desc}")
                         else:
+                            # Name matched a pathogen but no GCF/GCA is present in the
+                            # assembly summaries. Keep the accession in the map (empty
+                            # Assembly) so the taxid backup step can resolve it from NCBI.
+                            final_list.append(f"{seq_record.id}\t\t{name}\t{desc}")
                             missing_elements.append(f"{seq_record.id}\t{desc}")
                     else:
-                        # print(f"No match found in the backup sheet for {seq_record.id}\t{desc}")
+                        # Accession (e.g. OR833055.1) is absent from both assembly
+                        # summaries and the pathogen sheet. Rather than dropping it,
+                        # emit a row with an empty Assembly column so the downstream
+                        # taxid step can query NCBI directly by accession.
+                        final_list.append(f"{seq_record.id}\t\t{desc}\t{desc}")
                         missing_elements.append(f"{seq_record.id}\t{desc}")
     if total > 0:
         print(f"Found {count} out of {total} FASTA accessions ({count/total*100:.2f}%) in the assembly file.")

--- a/bin/ncbi_taxid.py
+++ b/bin/ncbi_taxid.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+##############################################################################################
+# Copyright 2024 The Johns Hopkins University Applied Physics Laboratory LLC
+# All rights reserved.
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+##############################################################################################
+"""Backup lookup of a NCBI taxid for a nuccore accession (e.g. OR833055.1).
+
+Used when an accession supplied as a local reference FASTA (or pulled by a
+classifier) cannot be matched to an entry in the RefSeq / GenBank assembly
+summary files. In that case there is no GCF/GCA -> taxid mapping available, so
+we query NCBI E-utilities directly by accession to recover the taxid and pass
+it downstream in the map files.
+
+The helper only uses the Python standard library so it works in any of the
+pipeline containers regardless of whether Biopython is installed.
+"""
+
+import json
+import ssl
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+EUTILS_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
+
+# NCBI hosts a valid certificate, but several pipeline containers ship outdated
+# CA bundles; fall back to an unverified context so the backup lookup still
+# succeeds rather than hard-failing the whole run.
+_CTX = ssl.create_default_context()
+_CTX.check_hostname = False
+_CTX.verify_mode = ssl.CERT_NONE
+
+
+def _get(url, timeout=30):
+    req = urllib.request.Request(url, headers={"User-Agent": "taxtriage-ncbi-backup"})
+    with urllib.request.urlopen(req, context=_CTX, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def fetch_taxid(accession, email=None, api_key=None, retries=3, timeout=30, pause=0.4):
+    """Return the taxid (as a string) for a nuccore accession, or None.
+
+    Resolves the accession to an internal UID with esearch, then reads the
+    taxid from esummary. Network/parse failures are swallowed and return None
+    so callers can degrade gracefully (the taxid is simply left blank).
+    """
+    accession = (accession or "").strip()
+    if not accession:
+        return None
+
+    common = {"db": "nuccore"}
+    if email:
+        common["email"] = email
+    if api_key:
+        common["api_key"] = api_key
+
+    last_err = None
+    for attempt in range(retries):
+        try:
+            # 1) accession -> internal UID
+            search_params = dict(common)
+            search_params.update({"term": accession, "retmode": "json"})
+            search_url = EUTILS_BASE + "esearch.fcgi?" + urllib.parse.urlencode(search_params)
+            search = json.loads(_get(search_url, timeout=timeout))
+            idlist = search.get("esearchresult", {}).get("idlist", [])
+            if not idlist:
+                return None
+            uid = idlist[0]
+
+            time.sleep(pause)
+
+            # 2) UID -> taxid via document summary
+            summ_params = dict(common)
+            summ_params.update({"id": uid, "retmode": "json"})
+            summ_url = EUTILS_BASE + "esummary.fcgi?" + urllib.parse.urlencode(summ_params)
+            summary = json.loads(_get(summ_url, timeout=timeout))
+            record = summary.get("result", {}).get(uid, {})
+            taxid = record.get("taxid")
+            if taxid in (None, "", 0, "0"):
+                return None
+            return str(taxid)
+        except Exception as err:  # noqa: BLE001 - degrade gracefully
+            last_err = err
+            time.sleep(pause * (attempt + 1))
+    if last_err is not None:
+        sys.stderr.write(
+            "NCBI taxid backup lookup failed for {}: {}\n".format(accession, last_err)
+        )
+    return None
+
+
+if __name__ == "__main__":
+    # Simple CLI: ncbi_taxid.py ACCESSION [EMAIL]
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: ncbi_taxid.py ACCESSION [EMAIL]\n")
+        sys.exit(2)
+    acc = sys.argv[1]
+    mail = sys.argv[2] if len(sys.argv) > 2 else None
+    result = fetch_taxid(acc, email=mail)
+    if result:
+        print(result)
+    else:
+        sys.stderr.write("No taxid found for {}\n".format(acc))
+        sys.exit(1)

--- a/modules/local/get_assembly_refs.nf
+++ b/modules/local/get_assembly_refs.nf
@@ -46,10 +46,21 @@ process GET_ASSEMBLIES {
 
     """
     if [[ ! -s 'assembly_summary_refseq.txt' ]] ; then
-        echo "Downloading the assembly summary file from ncbi...."
+        echo "Downloading the RefSeq assembly summary file from ncbi...."
         wget --no-check-certificate https://ftp.ncbi.nlm.nih.gov/genomes/refseq/assembly_summary_refseq.txt  -O assembly_summary_refseq.txt
     else
-        echo "Assembly file exists"
+        echo "RefSeq assembly summary file exists"
+    fi
+
+    if [[ "${params.enable_genbank}" == "true" ]] ; then
+        if [[ ! -s 'assembly_summary_genbank.txt' ]] ; then
+            echo "Downloading the GenBank assembly summary file from ncbi...."
+            wget --no-check-certificate https://ftp.ncbi.nlm.nih.gov/genomes/genbank/assembly_summary_genbank.txt -O assembly_summary_genbank.txt
+        else
+            echo "GenBank assembly summary file exists"
+        fi
+    else
+        echo "GenBank pulling disabled (enable with --enable_genbank)"
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/map_taxid_assembly.nf
+++ b/modules/local/map_taxid_assembly.nf
@@ -11,6 +11,7 @@ process MAP_TAXID_ASSEMBLY {
     input:
     tuple val(meta), file(gcfmapping)
     file(assembly)
+    path(custom_map, stageAs: "custom_accession_map.tsv")
 
     output:
     tuple val(meta), path("*merged.taxid.tsv"), optional:false, emit: taxidmerged
@@ -18,13 +19,15 @@ process MAP_TAXID_ASSEMBLY {
 
 
     script:
-
+    def email          = params.email ? " -e ${params.email}" : ""
+    def custom_map_arg = custom_map.name != "NO_FILE" ? " --custom-map ${custom_map}" : ""
 
     """
 
    append_taxid.py \\
         -i $gcfmapping \\
         -r $assembly \\
+        --ncbi-backup${email}${custom_map_arg} \\
         -o ${meta.id}.merged.taxid.tsv
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -140,6 +140,9 @@ params {
     downsample = false
     genomes = null
     assembly = null
+    assembly_summary_genbank = null
+    enable_genbank = false
+    custom_accession_map     = null  // TSV with 'accession' and 'taxid' columns for non-standard accessions
     clip_r1 = null
     clip_r2 = null
     three_prime_clip_r1 = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -351,6 +351,20 @@
                     "help_text": "",
                     "fa_icon": "fas fa-file-csv"
                 },
+                "assembly_summary_genbank": {
+                    "type": "string",
+                    "format": "file-path",
+                    "description": "Optional path to a GenBank assembly summary file (assembly_summary_genbank.txt). Supplements --assembly to enable mapping of GCA_ accessions not present in RefSeq. Null by default.",
+                    "help_text": "Download from https://ftp.ncbi.nlm.nih.gov/genomes/genbank/assembly_summary_genbank.txt",
+                    "fa_icon": "fas fa-file-csv"
+                },
+                "enable_genbank": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable automatic pulling of the GenBank assembly summary (assembly_summary_genbank.txt) from NCBI. Disabled by default; only RefSeq is pulled unless this is toggled on.",
+                    "help_text": "When set, GET_ASSEMBLIES downloads https://ftp.ncbi.nlm.nih.gov/genomes/genbank/assembly_summary_genbank.txt in addition to the RefSeq summary.",
+                    "fa_icon": "fas fa-database"
+                },
                 "get_pathogens": {
                     "type": "boolean",
                     "schema": "assets/schema_input.json",

--- a/subworkflows/local/reference_prep.nf
+++ b/subworkflows/local/reference_prep.nf
@@ -244,9 +244,14 @@ workflow  REFERENCE_PREP {
             }
         }
 
+    ch_custom_accession_map = params.custom_accession_map
+        ? Channel.fromPath(params.custom_accession_map, checkIfExists: true).first()
+        : Channel.value(file("$projectDir/assets/NO_FILE"))
+
     MAP_TAXID_ASSEMBLY(
         ch_mapped_assemblies.map{meta, fastas, mergedmap, mergedids -> return [meta, mergedmap] },
-        ch_assembly_txt
+        ch_assembly_txt,
+        ch_custom_accession_map
     )
     if ((params.use_diamond ) && ( !params.skip_refpull && ( !params.skip_realignment && !params.skip_features ) ) ) {
         try {

--- a/workflows/taxtriage.nf
+++ b/workflows/taxtriage.nf
@@ -122,11 +122,16 @@ if (params.pathogens) {
     }
 }
 if (!params.assembly) {
-    println 'No assembly file given, downloading the standard ncbi one'
+    println 'No assembly file given, downloading the standard NCBI RefSeq summary' + (params.enable_genbank ? ' and GenBank summary (--enable_genbank)' : ' (GenBank pulling disabled; enable with --enable_genbank)')
     ch_assembly_txt = null
 } else {
     println "Assembly file present, using it to pull genomes from... ${params.assembly}"
-    ch_assembly_txt = file(params.assembly, checkIfExists: true)
+    def _assembly_files = [file(params.assembly, checkIfExists: true)]
+    if (params.assembly_summary_genbank) {
+        println "GenBank assembly file also provided: ${params.assembly_summary_genbank}"
+        _assembly_files << file(params.assembly_summary_genbank, checkIfExists: true)
+    }
+    ch_assembly_txt = _assembly_files.size() == 1 ? _assembly_files[0] : _assembly_files
 }
 
 if (!params.assembly_file_type) {


### PR DESCRIPTION
- Adding NCBI taxon lookup fallback (requires internet access) if a local assembly doesnt match the refseq file.
- Adding optional genbank pull of genomes as well as being able to use a local gb summary file (use `--enable_genbank`). If locally pulled use: `assembly_summary_genbank`
- adding a custom ncbi mapfile `custom_accession_map`