### PR TITLE
250 merge samples support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 assets/mce.js
 docs/index.html
 _site/

--- a/assets/heatmap.html
+++ b/assets/heatmap.html
@@ -502,9 +502,9 @@
               </div>
               <div class="xs-note">
                 Aggregates every detection across the <b id="xs-nsamp">0</b> <span id="xs-unit">sample(s)</span> with a
-                positive hit (respects sidebar filters): how often each organism is seen, its TASS / coverage spread, how
-                samples cluster, and which organisms co-occur. Prevalence % is measured against all specimens with any
-                positive hit run-wide.
+                positive hit (respects sidebar filters): how often each organism is seen, its TASS / coverage spread,
+                how samples cluster, and which organisms co-occur. Prevalence % is measured against all specimens with
+                any positive hit run-wide.
               </div>
               <div class="tab-controls" id="xs-controls">
                 <div style="display: flex; gap: 0.3em; flex-wrap: wrap">
@@ -1295,7 +1295,11 @@
               <label>Sample:</label>
               <select id="hist-sample-sel" style="min-width: 140px"></select>
               <label id="hist-merge-mode-label" style="display: none">Merged view:</label>
-              <select id="hist-merge-mode-sel" style="display: none; min-width: 150px" title="With specimen merge on: show one coverage row per member sample, or combine each specimen's members into a single breadth curve for organisms hit in 2+ samples. Combined uses the exact positional union of coverage when available (label 'combined union'), else a per-bin max lower bound (label 'combined max').">
+              <select
+                id="hist-merge-mode-sel"
+                style="display: none; min-width: 150px"
+                title="With specimen merge on: show one coverage row per member sample, or combine each specimen's members into a single breadth curve for organisms hit in 2+ samples. Combined uses the exact positional union of coverage when available (label 'combined union'), else a per-bin max lower bound (label 'combined max')."
+              >
                 <option value="overlay" selected>Per sample</option>
                 <option value="combined">Combined breadth</option>
               </select>
@@ -2668,6 +2672,15 @@
           <div style="display: inline-flex; align-items: center; gap: 0.4em">
             <button
               type="button"
+              id="sidebar-help-btn"
+              class="sidebar-help-btn"
+              title="Right-panel help — walk through the filters, search, cutoff and sample colours"
+              aria-label="Right-panel help walkthrough"
+            >
+              <i class="fas fa-circle-question"></i>
+            </button>
+            <button
+              type="button"
               id="report-pdf-btn"
               class="export-control"
               title="Export Report PDF"
@@ -3081,15 +3094,7 @@
             background: #f6f9ff;
           "
         >
-          <span
-            style="
-              flex-basis: 100%;
-              font-size: 0.72em;
-              color: #0d47a1;
-              font-weight: 600;
-              white-space: nowrap;
-            "
-          >
+          <span style="flex-basis: 100%; font-size: 0.72em; color: #0d47a1; font-weight: 600; white-space: nowrap">
             <i class="fas fa-layer-group"></i> Specimens
           </span>
           <button
@@ -3153,13 +3158,7 @@
           </button>
           <span
             id="specimen-merge-count"
-            style="
-              flex-basis: 100%;
-              font-size: 0.68em;
-              color: #6b7c93;
-              margin: 0;
-              overflow-wrap: anywhere;
-            "
+            style="flex-basis: 100%; font-size: 0.68em; color: #6b7c93; margin: 0; overflow-wrap: anywhere"
           ></span>
         </div>
         <div
@@ -3171,21 +3170,45 @@
               <i
                 class="fas fa-magnifying-glass"
                 aria-hidden="true"
-                style="position: absolute; left: 7px; top: 50%; transform: translateY(-50%); color: #90a4ae; font-size: 0.72em"
+                style="
+                  position: absolute;
+                  left: 7px;
+                  top: 50%;
+                  transform: translateY(-50%);
+                  color: #90a4ae;
+                  font-size: 0.72em;
+                "
               ></i>
               <input
                 id="sample-list-search"
                 type="search"
                 placeholder="Search samples…"
                 aria-label="Search samples in the right panel"
-                style="box-sizing: border-box; width: 100%; padding: 4px 24px 4px 22px; border: 1px solid #c5d3e3; border-radius: 4px; font-size: 0.76em"
+                style="
+                  box-sizing: border-box;
+                  width: 100%;
+                  padding: 4px 24px 4px 22px;
+                  border: 1px solid #c5d3e3;
+                  border-radius: 4px;
+                  font-size: 0.76em;
+                "
               />
             </div>
             <select
               id="sample-list-page-size"
               aria-label="Samples per page"
               title="Samples per page"
-              style="flex: 0 0 52px; width: 52px; min-width: 52px; max-width: 52px; padding: 3px 2px; border: 1px solid #c5d3e3; border-radius: 4px; background: #fff; font-size: 0.7em"
+              style="
+                flex: 0 0 52px;
+                width: 52px;
+                min-width: 52px;
+                max-width: 52px;
+                padding: 3px 2px;
+                border: 1px solid #c5d3e3;
+                border-radius: 4px;
+                background: #fff;
+                font-size: 0.7em;
+              "
             >
               <option value="15">15</option>
               <option value="25" selected>25</option>
@@ -3194,11 +3217,49 @@
             </select>
           </div>
           <div style="display: inline-flex; align-items: center; gap: 2px; flex: 0 0 auto">
-            <button id="sample-list-prev" type="button" title="Previous sample page" aria-label="Previous sample page" style="padding: 2px 6px; border: 1px solid #c5d3e3; border-radius: 4px; background: #fff; color: #456; cursor: pointer">&#8249;</button>
-            <span id="sample-list-page-info" style="min-width: 44px; text-align: center; color: #607d8b; font-size: 0.68em">1 / 1</span>
-            <button id="sample-list-next" type="button" title="Next sample page" aria-label="Next sample page" style="padding: 2px 6px; border: 1px solid #c5d3e3; border-radius: 4px; background: #fff; color: #456; cursor: pointer">&#8250;</button>
+            <button
+              id="sample-list-prev"
+              type="button"
+              title="Previous sample page"
+              aria-label="Previous sample page"
+              style="
+                padding: 2px 6px;
+                border: 1px solid #c5d3e3;
+                border-radius: 4px;
+                background: #fff;
+                color: #456;
+                cursor: pointer;
+              "
+            >
+              &#8249;
+            </button>
+            <span
+              id="sample-list-page-info"
+              style="min-width: 44px; text-align: center; color: #607d8b; font-size: 0.68em"
+              >1 / 1</span
+            >
+            <button
+              id="sample-list-next"
+              type="button"
+              title="Next sample page"
+              aria-label="Next sample page"
+              style="
+                padding: 2px 6px;
+                border: 1px solid #c5d3e3;
+                border-radius: 4px;
+                background: #fff;
+                color: #456;
+                cursor: pointer;
+              "
+            >
+              &#8250;
+            </button>
           </div>
-          <div id="sample-list-match-info" aria-live="polite" style="flex-basis: 100%; color: #78909c; font-size: 0.66em"></div>
+          <div
+            id="sample-list-match-info"
+            aria-live="polite"
+            style="flex-basis: 100%; color: #78909c; font-size: 0.66em"
+          ></div>
         </div>
         <div id="sample-list"></div>
         <h3>Upload Data</h3>
@@ -3277,7 +3338,7 @@
           Save a self-contained snapshot of the current data <em>and</em> all filters, then reload it later to return to
           exactly this view.
         </span>
-        <div style="display: flex; gap: 0.4em; flex-wrap: wrap">
+        <div id="state-io-row" style="display: flex; gap: 0.4em; flex-wrap: wrap">
           <button class="upload-btn" onclick="window.ttExportState && window.ttExportState()">
             <i class="fas fa-download" style="margin-right: 0.35em"></i>Export State
           </button>

--- a/assets/heatmap.html
+++ b/assets/heatmap.html
@@ -501,9 +501,10 @@
                 </button>
               </div>
               <div class="xs-note">
-                Aggregates every detection across the <b id="xs-nsamp">0</b> sample(s) currently in view (respects
-                sidebar filters): how often each organism is seen, its TASS / coverage spread, how samples cluster, and
-                which organisms co-occur.
+                Aggregates every detection across the <b id="xs-nsamp">0</b> <span id="xs-unit">sample(s)</span> with a
+                positive hit (respects sidebar filters): how often each organism is seen, its TASS / coverage spread, how
+                samples cluster, and which organisms co-occur. Prevalence % is measured against all specimens with any
+                positive hit run-wide.
               </div>
               <div class="tab-controls" id="xs-controls">
                 <div style="display: flex; gap: 0.3em; flex-wrap: wrap">
@@ -539,6 +540,43 @@
                   <option value="Coverage">Coverage</option>
                   <option value="presence" selected>Presence (0/1)</option>
                 </select>
+                <label
+                  id="xs-specimen-lbl"
+                  title="Merge samples that share a specimen id (e.g. DNA + RNA libraries from one swab) into a single specimen. Prevalence and per-organism TASS / coverage / reads then aggregate per specimen."
+                  >Specimens</label
+                >
+                <button
+                  id="xs-specimen-toggle"
+                  title="Toggle specimen merge on/off"
+                  style="
+                    padding: 0.22em 0.7em;
+                    border: 1px solid #1565c0;
+                    border-radius: 5px;
+                    background: #fff;
+                    color: #1565c0;
+                    font-size: 0.82em;
+                    font-weight: 600;
+                    cursor: pointer;
+                  "
+                >
+                  Merge: Off
+                </button>
+                <button
+                  id="xs-specimen-edit"
+                  title="Edit which samples belong to each specimen"
+                  style="
+                    padding: 0.22em 0.7em;
+                    border: 1px solid #1565c0;
+                    border-radius: 5px;
+                    background: #fff;
+                    color: #1565c0;
+                    font-size: 0.82em;
+                    font-weight: 600;
+                    cursor: pointer;
+                  "
+                >
+                  Edit…
+                </button>
                 <label id="xs-topn-lbl">Top organisms</label>
                 <select id="xs-topn">
                   <option value="15">15</option>
@@ -1256,6 +1294,11 @@
               <button id="hist-org-search-clear" type="button" style="padding: 0.25em 0.6em">Clear</button>
               <label>Sample:</label>
               <select id="hist-sample-sel" style="min-width: 140px"></select>
+              <label id="hist-merge-mode-label" style="display: none">Merged view:</label>
+              <select id="hist-merge-mode-sel" style="display: none; min-width: 150px" title="With specimen merge on: show one coverage row per member sample, or combine each specimen's members into a single breadth curve for organisms hit in 2+ samples. Combined uses the exact positional union of coverage when available (label 'combined union'), else a per-bin max lower bound (label 'combined max').">
+                <option value="overlay" selected>Per sample</option>
+                <option value="combined">Combined breadth</option>
+              </select>
               <label>Metric:</label>
               <select id="hist-metric-sel">
                 <option value="reads" selected>Reads Aligned</option>
@@ -3022,6 +3065,141 @@
             </button>
           </span>
         </h3>
+        <div
+          id="specimen-merge-bar"
+          style="
+            display: none;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.4em;
+            box-sizing: border-box;
+            width: 100%;
+            margin: 0 0 0.4em;
+            padding: 5px 7px;
+            border: 1px solid #d6e2f5;
+            border-radius: 5px;
+            background: #f6f9ff;
+          "
+        >
+          <span
+            style="
+              flex-basis: 100%;
+              font-size: 0.72em;
+              color: #0d47a1;
+              font-weight: 600;
+              white-space: nowrap;
+            "
+          >
+            <i class="fas fa-layer-group"></i> Specimens
+          </span>
+          <button
+            id="specimen-merge-toggle"
+            type="button"
+            style="
+              flex: 0 0 auto;
+              font-size: 0.7em;
+              padding: 3px 10px;
+              border: 1px solid #1565c0;
+              border-radius: 4px;
+              background: #fff;
+              color: #1565c0;
+              cursor: pointer;
+              white-space: nowrap;
+              font-weight: 600;
+              line-height: 1.5;
+            "
+          >
+            Merge: Off
+          </button>
+          <button
+            id="specimen-merge-group-btn"
+            type="button"
+            title="Drag samples together to build specimens and name them"
+            style="
+              flex: 0 0 auto;
+              font-size: 0.7em;
+              padding: 3px 10px;
+              border: 1px solid #1565c0;
+              border-radius: 4px;
+              background: #f0f7ff;
+              color: #0d47a1;
+              cursor: pointer;
+              white-space: nowrap;
+              font-weight: 600;
+              line-height: 1.5;
+            "
+          >
+            <i class="fas fa-object-group"></i> Group…
+          </button>
+          <button
+            id="specimen-merge-combine-all-btn"
+            type="button"
+            title="Combine every sample into a single specimen in one click (reads summed, TASS taken as the max)"
+            style="
+              flex: 0 0 auto;
+              font-size: 0.7em;
+              padding: 3px 10px;
+              border: 1px solid #1565c0;
+              border-radius: 4px;
+              background: #f0f7ff;
+              color: #0d47a1;
+              cursor: pointer;
+              white-space: nowrap;
+              font-weight: 600;
+              line-height: 1.5;
+            "
+          >
+            <i class="fas fa-object-ungroup"></i> Combine all
+          </button>
+          <span
+            id="specimen-merge-count"
+            style="
+              flex-basis: 100%;
+              font-size: 0.68em;
+              color: #6b7c93;
+              margin: 0;
+              overflow-wrap: anywhere;
+            "
+          ></span>
+        </div>
+        <div
+          id="sample-list-tools"
+          style="display: flex; flex-wrap: wrap; align-items: center; gap: 4px; margin: 0 0 0.4em"
+        >
+          <div style="display: flex; align-items: center; gap: 4px; flex: 1 0 100%; min-width: 0">
+            <div style="position: relative; flex: 1 1 auto; min-width: 0">
+              <i
+                class="fas fa-magnifying-glass"
+                aria-hidden="true"
+                style="position: absolute; left: 7px; top: 50%; transform: translateY(-50%); color: #90a4ae; font-size: 0.72em"
+              ></i>
+              <input
+                id="sample-list-search"
+                type="search"
+                placeholder="Search samples…"
+                aria-label="Search samples in the right panel"
+                style="box-sizing: border-box; width: 100%; padding: 4px 24px 4px 22px; border: 1px solid #c5d3e3; border-radius: 4px; font-size: 0.76em"
+              />
+            </div>
+            <select
+              id="sample-list-page-size"
+              aria-label="Samples per page"
+              title="Samples per page"
+              style="flex: 0 0 52px; width: 52px; min-width: 52px; max-width: 52px; padding: 3px 2px; border: 1px solid #c5d3e3; border-radius: 4px; background: #fff; font-size: 0.7em"
+            >
+              <option value="15">15</option>
+              <option value="25" selected>25</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </div>
+          <div style="display: inline-flex; align-items: center; gap: 2px; flex: 0 0 auto">
+            <button id="sample-list-prev" type="button" title="Previous sample page" aria-label="Previous sample page" style="padding: 2px 6px; border: 1px solid #c5d3e3; border-radius: 4px; background: #fff; color: #456; cursor: pointer">&#8249;</button>
+            <span id="sample-list-page-info" style="min-width: 44px; text-align: center; color: #607d8b; font-size: 0.68em">1 / 1</span>
+            <button id="sample-list-next" type="button" title="Next sample page" aria-label="Next sample page" style="padding: 2px 6px; border: 1px solid #c5d3e3; border-radius: 4px; background: #fff; color: #456; cursor: pointer">&#8250;</button>
+          </div>
+          <div id="sample-list-match-info" aria-live="polite" style="flex-basis: 100%; color: #78909c; font-size: 0.66em"></div>
+        </div>
         <div id="sample-list"></div>
         <h3>Upload Data</h3>
         <div
@@ -3402,6 +3580,7 @@
     <script src="src/js/34_cross_entry_comparison.js"></script>
     <script src="src/js/35_tab_map.js"></script>
     <script src="src/js/36_guided_help_tour.js"></script>
+    <script src="src/js/37_specimen_merge.js"></script>
     <!-- Novelty floating cell tooltip — referenced by _novCellTip() -->
     <div id="nov-cell-tip"></div>
   </body>

--- a/assets/src/css/main.css
+++ b/assets/src/css/main.css
@@ -3351,6 +3351,278 @@ body.help-active .help-spot-el {
   }
 }
 
+/* ═══════════════════════════════════════════════════════════════════
+   Inline "?" right-panel help button (sits before Export Report)
+   ═══════════════════════════════════════════════════════════════════ */
+.sidebar-help-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid #cfd8e3;
+  border-radius: 50%;
+  background: #f2f7fd;
+  color: #1565c0;
+  font-size: 0.82em;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    box-shadow 0.15s,
+    transform 0.1s;
+}
+.sidebar-help-btn:hover {
+  background: #e3f0fd;
+  border-color: #90b8e0;
+  box-shadow: 0 0 0 3px rgba(33, 150, 243, 0.16);
+}
+.sidebar-help-btn:active {
+  transform: scale(0.94);
+}
+.sidebar-help-btn.on {
+  background: #1565c0;
+  border-color: #1565c0;
+  color: #fff;
+  box-shadow: 0 0 0 3px rgba(21, 101, 192, 0.28);
+}
+
+/* replay link injected into the per-tab help panel foot */
+#tab-help-walk {
+  display: inline-block;
+  margin-bottom: 7px;
+  font-weight: 700;
+  color: #1565c0;
+  text-decoration: none;
+}
+#tab-help-walk:hover {
+  text-decoration: underline;
+}
+#tab-help-walk i {
+  font-size: 0.85em;
+  margin-right: 3px;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Spotlight walkthrough (moving ring + pinned popover) — used by the
+   per-tab Help mode and the right-panel "?" button. The little
+   bottom-left #tab-help-panel (z 8500) stays visible above the dim.
+   ═══════════════════════════════════════════════════════════════════ */
+#hs-dim {
+  position: fixed;
+  inset: 0;
+  z-index: 8000;
+  background: rgba(8, 18, 32, 0.6);
+  backdrop-filter: blur(1.5px);
+  -webkit-backdrop-filter: blur(1.5px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.22s ease;
+}
+#hs-dim.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+/* raise the element being described above the dim so it stays readable */
+body.hs-open .hs-target {
+  position: relative;
+  z-index: 8100;
+  border-radius: 8px;
+}
+#hs-ring {
+  position: fixed;
+  z-index: 8600;
+  border: 3px solid #2196f3;
+  border-radius: 10px;
+  box-shadow:
+    0 0 0 3px rgba(255, 255, 255, 0.55),
+    0 0 22px 5px rgba(33, 150, 243, 0.8);
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    top 0.25s ease,
+    left 0.25s ease,
+    width 0.25s ease,
+    height 0.25s ease,
+    opacity 0.2s ease;
+  animation: hsRingPulse 1.7s ease-in-out infinite;
+}
+#hs-ring.show {
+  opacity: 1;
+}
+@keyframes hsRingPulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 3px rgba(255, 255, 255, 0.55),
+      0 0 18px 4px rgba(33, 150, 243, 0.65);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px rgba(255, 255, 255, 0.6),
+      0 0 30px 9px rgba(33, 150, 243, 0.95);
+  }
+}
+#hs-pop {
+  position: fixed;
+  z-index: 8700;
+  width: 320px;
+  max-width: 92vw;
+  background: linear-gradient(180deg, #ffffff, #f4f9ff);
+  border: 1px solid rgba(21, 101, 192, 0.25);
+  border-radius: 14px;
+  box-shadow: 0 14px 44px rgba(2, 22, 48, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.97);
+  transition:
+    top 0.25s ease,
+    left 0.25s ease,
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+#hs-pop.show {
+  opacity: 1;
+  pointer-events: auto;
+  transform: scale(1);
+}
+#hs-pop-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.6em 0.75em;
+  background: linear-gradient(135deg, #0d47a1, #1976d2);
+  color: #fff;
+  border-radius: 14px 14px 0 0;
+}
+#hs-pop-ico {
+  font-size: 1.05em;
+}
+#hs-pop-title {
+  margin: 0;
+  font-size: 0.95em;
+  font-weight: 800;
+  flex: 1 1 auto;
+  line-height: 1.2;
+}
+#hs-pop-step {
+  font-size: 0.7em;
+  font-weight: 700;
+  opacity: 0.9;
+  white-space: nowrap;
+}
+#hs-pop-x {
+  border: none;
+  background: none;
+  color: #fff;
+  font-size: 1.15em;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.85;
+  padding: 0 0.15em;
+}
+#hs-pop-x:hover {
+  opacity: 1;
+}
+#hs-pop-body {
+  padding: 0.75em 0.85em 0.3em;
+  font-size: 0.86em;
+  color: #33475b;
+  line-height: 1.5;
+}
+#hs-pop-tips {
+  list-style: none;
+  margin: 0;
+  padding: 0 0.85em 0.4em;
+}
+#hs-pop-tips li {
+  position: relative;
+  font-size: 0.8em;
+  color: #46586c;
+  line-height: 1.4;
+  padding: 0.12em 0 0.12em 1.35em;
+}
+#hs-pop-tips li::before {
+  content: "\f054";
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
+  color: #2196f3;
+  position: absolute;
+  left: 0.2em;
+  top: 0.24em;
+  font-size: 0.72em;
+}
+#hs-pop-foot {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.55em 0.75em 0.65em;
+  border-top: 1px solid #e6eef7;
+}
+#hs-pop-foot .hs-spacer {
+  flex: 1 1 auto;
+}
+#hs-pop-dots {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+.hs-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #c2d4e8;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    transform 0.15s;
+}
+.hs-dot:hover {
+  background: #90b8e0;
+}
+.hs-dot.on {
+  background: #1565c0;
+  transform: scale(1.3);
+}
+#hs-pop-foot button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  border: none;
+  border-radius: 8px;
+  padding: 0.42em 0.85em;
+  font-size: 0.82em;
+  font-weight: 700;
+  cursor: pointer;
+}
+#hs-back {
+  background: #e6eef7;
+  color: #325074;
+}
+#hs-back:hover {
+  background: #d6e3f2;
+}
+#hs-back:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+#hs-next {
+  background: linear-gradient(90deg, #1565c0, #2196f3);
+  color: #fff;
+  box-shadow: 0 3px 12px rgba(33, 150, 243, 0.4);
+}
+#hs-next:hover {
+  filter: brightness(1.07);
+}
+/* keep the spotlight overlay out of exported PDFs */
+body.report-pdf-printing #hs-dim,
+body.report-pdf-printing #hs-ring,
+body.report-pdf-printing #hs-pop {
+  display: none !important;
+}
+
 /* ═══ Enhanced sidebar search ═══════════════════════════════════════ */
 #filter-search-box {
   position: relative;

--- a/assets/src/js/01_global_state.js
+++ b/assets/src/js/01_global_state.js
@@ -11,6 +11,168 @@ const perTypeTass = {}; // per-sample-type TASS override: { "stool": 65, "blood"
 const _loadingSampleIds = new Set(); // samples currently ingesting an attached file (drives the per-row spinner)
 let _sampleOrder = []; // custom display order for samples (index → id)
 
+/* ── Specimen grouping (merge DNA/RNA libraries of one specimen) ──────────
+       A "specimen" groups one or more samples (e.g. a separate DNA and RNA
+       library from the same swab) into a single biological unit. The grouping
+       is supplied by the samplesheet `specimen` column, which flows through the
+       pipeline into SAMPLE_META[sample].specimen, and can be overridden live in
+       the report via SPECIMEN_OVERRIDE. When specimenMergeEnabled is on, the
+       cross-sample views aggregate hits / TASS / coverage per specimen instead
+       of per sample, and prevalence is computed over specimens. */
+let specimenMergeEnabled = false;
+const SPECIMEN_OVERRIDE = {}; // sample_name → specimen group (live UI edits win)
+
+/** Resolve the specimen a sample belongs to, independent of the merge toggle.
+ *  Priority: live override → samplesheet metadata → the sample name itself
+ *  (a sample with no specimen assignment is its own specimen). */
+function specimenOf(sample) {
+  const s = String(sample == null ? "" : sample);
+  if (!s) return s;
+  if (Object.prototype.hasOwnProperty.call(SPECIMEN_OVERRIDE, s) && SPECIMEN_OVERRIDE[s]) {
+    return String(SPECIMEN_OVERRIDE[s]);
+  }
+  const meta = (typeof SAMPLE_META !== "undefined" && SAMPLE_META[s]) || {};
+  const sp = meta.specimen != null ? meta.specimen : meta.specimen_id != null ? meta.specimen_id : meta.specimen_group;
+  return sp != null && String(sp).trim() ? String(sp).trim() : s;
+}
+
+/** The key cross-sample views should group rows by: the specimen when merging
+ *  is enabled, otherwise the raw sample (Specimen ID) name. */
+function specimenKey(sample) {
+  return specimenMergeEnabled ? specimenOf(sample) : String(sample == null ? "" : sample);
+}
+
+/** Give every multi-sample specimen a stable color so legends, the heatmap,
+ *  the coverage plots and the right-panel all render the merged unit in a
+ *  consistent hue. A specimen inherits its first member's color (visually
+ *  linking them); brand-new specimen names with no colored member fall back to
+ *  the shared PALETTE. Idempotent — only fills gaps, never recolors. */
+function _ensureSpecimenColors() {
+  if (typeof specimenGroups !== "function") return;
+  let i = Object.keys(sampleColors).length;
+  specimenGroups().forEach((members, g) => {
+    if (members.length > 1 && !sampleColors[g]) {
+      sampleColors[g] = sampleColors[members[0]] || PALETTE[i++ % PALETTE.length];
+    }
+  });
+}
+
+/** True when merging is active AND this sample has been folded into a
+ *  specimen that carries a different name (i.e. it no longer appears in the
+ *  merged view under its own id). Per-sample section / indicator builders use
+ *  this to avoid rendering an empty "no detections" row for a member sample
+ *  whose rows were relabelled onto its specimen. */
+function _isMergedAway(sample) {
+  if (!specimenMergeEnabled) return false;
+  const s = String(sample == null ? "" : sample);
+  return !!s && specimenOf(s) !== s;
+}
+
+/** Whether any sample is actually assigned to a multi-sample specimen (via
+ *  metadata or a live override). Lets the UI hide the merge control when the
+ *  run has no specimen grouping to act on. */
+function hasSpecimenGrouping() {
+  const groups = specimenGroups();
+  for (const members of groups.values()) if (members.length > 1) return true;
+  return false;
+}
+
+/** Map every known specimen → sorted list of its member samples, using
+ *  SAMPLE_META (all samples) plus any live overrides and anything seen in DATA. */
+function specimenGroups() {
+  const groups = new Map();
+  const add = (sample) => {
+    const s = String(sample == null ? "" : sample);
+    if (!s) return;
+    const g = specimenOf(s);
+    if (!groups.has(g)) groups.set(g, new Set());
+    groups.get(g).add(s);
+  };
+  Object.keys((typeof SAMPLE_META !== "undefined" && SAMPLE_META) || {}).forEach(add);
+  if (typeof DATA !== "undefined") DATA.forEach((r) => add(r["Specimen ID"]));
+  const out = new Map();
+  Array.from(groups.keys())
+    .sort()
+    .forEach((g) => out.set(g, Array.from(groups.get(g)).sort()));
+  return out;
+}
+
+/** Small, consistent visual marker used beside sample/specimen names in the
+ *  Summary, full Table and Metadata tables. Pass either a collapsed detection
+ *  row (__mergedFrom) or a raw sample id. Returns an empty string unless the
+ *  item is currently part of an active multi-sample specimen. */
+function _mergedSampleBadgeHTML(item) {
+  if (!(typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled)) return "";
+  const esc = (v) =>
+    String(v == null ? "" : v)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  let specimen = "",
+    members = [];
+  if (item && typeof item === "object") {
+    specimen = String(item["Specimen ID"] || "");
+    members = Array.isArray(item.__specimenMembers)
+      ? item.__specimenMembers.slice()
+      : Array.isArray(item.__mergedFrom)
+      ? item.__mergedFrom.slice()
+      : [];
+    if (members.length < 2 && typeof specimenGroups === "function") {
+      members = (specimenGroups().get(specimen) || members).slice();
+    }
+  } else {
+    const sample = String(item == null ? "" : item);
+    specimen = typeof specimenOf === "function" ? specimenOf(sample) : sample;
+    const groups = typeof specimenGroups === "function" ? specimenGroups() : new Map();
+    members = (groups.get(specimen) || []).slice();
+  }
+  if (members.length < 2) return "";
+  const title = `Merged specimen: ${specimen} (${members.length} samples: ${members.join(", ")})`;
+  return (
+    `<span class="merged-sample-badge" title="${esc(title)}" ` +
+    `style="display:inline-flex;align-items:center;gap:3px;margin-left:5px;padding:0 5px;` +
+    `border:1px solid #90caf9;border-radius:8px;background:#e3f2fd;color:#0d47a1;` +
+    `font-size:9px;font-weight:700;line-height:1.55;vertical-align:middle;white-space:nowrap">` +
+    `<i class="fas fa-layer-group" aria-hidden="true"></i> merged ×${members.length}</span>`
+  );
+}
+
+/** Fingerprint of everything that changes specimen aggregation, for the
+ *  filteredData() cache key. Changes when the merge toggle flips or any live
+ *  SPECIMEN_OVERRIDE assignment is edited. */
+function _hashSpecimenMerge() {
+  const ov = Object.keys(SPECIMEN_OVERRIDE)
+    .sort()
+    .map((k) => k + "=" + SPECIMEN_OVERRIDE[k])
+    .join(",");
+  return (specimenMergeEnabled ? "1" : "0") + "|" + ov;
+}
+
+/** User-chosen resolutions for metadata that conflicts across the samples of a
+ *  merged specimen (e.g. differing lat/long). Keyed specimen → { field: value }.
+ *  Populated by the merge modal's conflict chooser; read best-effort by views
+ *  that surface per-specimen metadata. */
+const SPECIMEN_META_RESOLVED = {};
+
+/** Prevalence denominator: the number of distinct specimens (respecting the
+ *  merge toggle) that have at least one positive hit (Passes Threshold)
+ *  anywhere in the run. Deliberately decoupled from the live TASS slider so
+ *  prevalence is measured against everything that tested positive, not just
+ *  what clears the current threshold. */
+function positiveHitSpecimenCount() {
+  const seen = new Set();
+  if (typeof DATA !== "undefined") {
+    DATA.forEach((r) => {
+      if (typeof isTruthy === "function" ? isTruthy(r["Passes Threshold"]) : r["Passes Threshold"]) {
+        const k = specimenKey(r["Specimen ID"]);
+        if (k) seen.add(k);
+      }
+    });
+  }
+  return seen.size;
+}
+
 /** Return arr sorted by _sampleOrder; unknowns go to the end. */
 function _orderedSamples(arr) {
   if (!_sampleOrder.length) return arr;

--- a/assets/src/js/01_global_state.js
+++ b/assets/src/js/01_global_state.js
@@ -173,15 +173,41 @@ function positiveHitSpecimenCount() {
   return seen.size;
 }
 
-/** Return arr sorted by _sampleOrder; unknowns go to the end. */
+/** Return arr sorted by _sampleOrder; unknowns go to the end. `arr` may
+ *  contain raw sample ids or specimen/group names (callers pass whichever
+ *  filteredData() rows carry under "Specimen ID" — a group name once
+ *  specimen merge is on), so the lookup below must resolve both. */
 function _orderedSamples(arr) {
   if (!_sampleOrder.length) return arr;
-  const idx = Object.fromEntries(_sampleOrder.map((id, i) => [id, i]));
+  const idx = _sampleOrGroupIndexMap();
   return [...arr].sort((a, b) => {
     const ia = idx[a] !== undefined ? idx[a] : 9999;
     const ib = idx[b] !== undefined ? idx[b] : 9999;
     return ia - ib;
   });
+}
+
+/** Build a lookup from "row group key" → right-panel display position, for
+ *  tables/plots that sort by the row's "Specimen ID" field. That field holds
+ *  the raw sample id normally, but holds the *specimen/group name* once
+ *  specimen merge is enabled (see specimenKey()) — a string that never
+ *  appears in _sampleOrder itself (which only lists individual sample ids).
+ *  A plain `_sampleOrder.map((id,i)=>[id,i])` lookup therefore misses every
+ *  merged group and silently sorts it to the end, which is why grouped views
+ *  used to ignore the sidebar drag order. Here, each specimen/group name is
+ *  additionally keyed to the earliest position any of its member samples
+ *  occupies in _sampleOrder, so dragging a specimen's row block in the
+ *  sidebar (or a whole merged-specimen header) is reflected everywhere rows
+ *  are grouped by "Specimen ID". */
+function _sampleOrGroupIndexMap() {
+  const idx = {};
+  if (!_sampleOrder.length) return idx;
+  _sampleOrder.forEach((id, i) => {
+    if (idx[id] === undefined) idx[id] = i;
+    const g = typeof specimenOf === "function" ? specimenOf(id) : id;
+    if (g && idx[g] === undefined) idx[g] = i;
+  });
+  return idx;
 }
 let sortCol = null;
 let sortAsc = true;

--- a/assets/src/js/02_utilities.js
+++ b/assets/src/js/02_utilities.js
@@ -359,7 +359,8 @@ function _collapseSpecimens(rows) {
         : members;
     const activeMembers = specimenMembers.filter((s) => !sampleHidden[s]);
     const inputReads = activeMembers.reduce(
-      (s, sample) => s + (parseFloat(((typeof SAMPLE_META !== "undefined" && SAMPLE_META[sample]) || {}).total_reads) || 0),
+      (s, sample) =>
+        s + (parseFloat(((typeof SAMPLE_META !== "undefined" && SAMPLE_META[sample]) || {}).total_reads) || 0),
       0,
     );
     const classifiedReads = activeMembers.reduce(
@@ -389,7 +390,9 @@ function _collapseSpecimens(rows) {
 function _sameOrgLevel(a, b) {
   const ka = (a["Taxonomic ID #"] || a["Detected Organism"] || "").toString();
   const kb = (b["Taxonomic ID #"] || b["Detected Organism"] || "").toString();
-  return ka === kb && (a["Level"] || "Strain") === (b["Level"] || "Strain") && (a["Subkey"] || "") === (b["Subkey"] || "");
+  return (
+    ka === kb && (a["Level"] || "Strain") === (b["Level"] || "Strain") && (a["Subkey"] || "") === (b["Subkey"] || "")
+  );
 }
 
 /* Return a shallow copy of row r with TASS Score + Coverage scaled ×100
@@ -1790,8 +1793,7 @@ function _esc(s) {
 function _pdfKpiCards() {
   const fd = typeof filteredData === "function" ? filteredData() : [];
   const samples = uniq(fd.map((r) => r["Specimen ID"] || "")).filter(Boolean);
-  const metaFor = (sn) =>
-    typeof _summaryMetaFor === "function" ? _summaryMetaFor(sn, fd) : SAMPLE_META[sn] || {};
+  const metaFor = (sn) => (typeof _summaryMetaFor === "function" ? _summaryMetaFor(sn, fd) : SAMPLE_META[sn] || {});
   const totalInput = samples.reduce((s, sn) => s + (parseFloat(metaFor(sn).total_reads) || 0), 0);
   const totalInputUnfiltered = Object.keys(SAMPLE_META || {}).reduce(
     (s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_reads) || 0),
@@ -1832,7 +1834,7 @@ function _pdfKpiCards() {
       sub: "aligned + unaligned, without filters",
     },
     { label: "% Classified", value: pctClass, sub: aReads.short + " aligned" },
-    { label: "Organisms", value: _fmtInt(uniqOrgs), sub: "unique taxa" },
+    { label: "Organisms", value: _fmtInt(uniqOrgs), sub: "unique (passing filter taxa)." },
     { label: "Genera", value: _fmtInt(uniqGenera), sub: "unique genera" },
     { label: "High Consequence", value: _fmtInt(hcCount), sub: "flagged", hc: true },
     { label: "TASS Cutoff", value: cutVal, sub: cutSub },

--- a/assets/src/js/02_utilities.js
+++ b/assets/src/js/02_utilities.js
@@ -112,6 +112,7 @@ function filteredData() {
     viewLevel,
     watchFilterMode,
     watchFilterMode === "all" ? "" : Array.from(watchlist).sort().join(","),
+    typeof _hashSpecimenMerge === "function" ? _hashSpecimenMerge() : "",
   ].join("\u0001");
   if (_FD_CACHE.key === cacheKey && _FD_CACHE.value) return _FD_CACHE.value;
 
@@ -137,7 +138,14 @@ function filteredData() {
   function _basePass(r) {
     if (sampleHidden[r["Specimen ID"]]) return false;
     if (rx) {
-      const inSample = rx.test(r["Specimen ID"] || "");
+      // Match both the raw library id and its current specimen label. Without
+      // this, a user-created merged name could be displayed but not searched.
+      const rawSample = r["Specimen ID"] || "";
+      const viewSample =
+        typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled && typeof specimenOf === "function"
+          ? specimenOf(rawSample)
+          : rawSample;
+      const inSample = rx.test(rawSample) || (viewSample !== rawSample && rx.test(viewSample));
       const inOrg = rx.test(r["Detected Organism"] || "");
       if (scope === "sample") {
         if (!inSample) return false;
@@ -225,9 +233,163 @@ function filteredData() {
   }
   // Skip the .map(applyRescale) allocation entirely when no sample is
   // currently rescaled — saves a 14k-object copy on every filter pass.
-  const out = anyRescale ? finalRows.map(applyRescale) : finalRows;
+  let out = anyRescale ? finalRows.map(applyRescale) : finalRows;
+  // ── Specimen merge (reversible, view-level) ─────────────────────────
+  // When the merge toggle is on and the run actually has multi-sample
+  // specimens, collapse the per-sample rows into per-specimen rows so every
+  // downstream view (table, heatmap, summary, coverage …) sees aggregated
+  // reads / TASS without the underlying DATA ever being mutated.
+  if (
+    typeof specimenMergeEnabled !== "undefined" &&
+    specimenMergeEnabled &&
+    typeof hasSpecimenGrouping === "function" &&
+    hasSpecimenGrouping()
+  ) {
+    out = _collapseSpecimens(out);
+  }
   _FD_CACHE = { key: cacheKey, value: out };
   return out;
+}
+
+/* ── Collapse filtered rows into one row per (specimen, organism) ─────────
+        Reversible aggregation used only for the merged VIEW — the source DATA
+        array is never touched, so flipping the toggle off restores the raw
+        per-sample rows immediately.
+
+        Aggregation rules (chosen with the user):
+          • aligned / unique / classifier read counts → SUM across the samples
+          • % Reads / RPM / RPKM                     → recomputed from the
+                                                        merged count + denominator
+          • TASS / Coverage / Breadth / evidence scores
+                                                      → MAX (strongest evidence
+                                                        in any library wins)
+          • Mean Depth                                → SUM (depth from independent
+                                                        libraries is additive)
+          • Mean MapQ / Mean BaseQ                    → read-weighted mean
+          • High Consequence / Passes Threshold        → OR (any true ⇒ true)
+          • Mol Type                                   → "both" if the members
+                                                        mix DNA and RNA, else
+                                                        the single value
+          • every other column                         → taken from the member
+                                                        row with the highest TASS
+        Single-sample specimens pass through unchanged (their key is the sample
+        name itself, so no aggregation happens).                              */
+const _SPECIMEN_SUM_COLS = ["# Reads Aligned", "# Unique Reads Aligned", "# Reads", "K2 Reads", "Mean Depth"];
+const _SPECIMEN_MAX_COLS = [
+  "TASS Score",
+  "Species TASS",
+  "Genus TASS",
+  "Coverage",
+  "Covered Bases",
+  "Breadth %",
+  "Breadth Score",
+  "Breadth of Coverage",
+  "Gini Coefficient",
+  "Minhash Score",
+  "MapQ Score",
+  "Disparity Score",
+  "Diamond Identity",
+  "MicrobeRT Probability",
+];
+function _collapseSpecimens(rows) {
+  const groups = new Map();
+  for (const r of rows) {
+    const spec = specimenOf(r["Specimen ID"]);
+    const orgKey = (r["Taxonomic ID #"] || r["Detected Organism"] || "").toString();
+    const key = [spec, r["Level"] || "Strain", r["Subkey"] || "", orgKey].join("");
+    let g = groups.get(key);
+    if (!g) {
+      g = { spec, members: new Set(), rep: r, repTass: num(r["TASS Score"]) };
+      groups.set(key, g);
+    }
+    g.members.add(r["Specimen ID"]);
+    const t = num(r["TASS Score"]);
+    if (t > g.repTass) {
+      g.repTass = t;
+      g.rep = r;
+    }
+  }
+  const out = [];
+  groups.forEach((g) => {
+    const members = Array.from(g.members).sort();
+    // A specimen with a single contributing sample needs no aggregation.
+    if (members.length <= 1 && specimenOf(members[0]) === members[0]) {
+      out.push(g.rep);
+      return;
+    }
+    const merged = Object.assign({}, g.rep);
+    merged["Specimen ID"] = g.spec;
+    const contrib = rows.filter((r) => specimenOf(r["Specimen ID"]) === g.spec && _sameOrgLevel(r, g.rep));
+    _SPECIMEN_SUM_COLS.forEach((c) => {
+      let any = false;
+      const s = contrib.reduce((acc, r) => {
+        if (r[c] !== undefined && r[c] !== null && r[c] !== "") any = true;
+        return acc + num(r[c]);
+      }, 0);
+      if (any) merged[c] = s;
+    });
+    _SPECIMEN_MAX_COLS.forEach((c) => {
+      let any = false;
+      const m = contrib.reduce((acc, r) => {
+        const v = num(r[c]);
+        if (r[c] !== undefined && r[c] !== null && r[c] !== "") any = true;
+        return v > acc ? v : acc;
+      }, -Infinity);
+      if (any) merged[c] = m;
+    });
+    // Quality means must be weighted by the reads that contributed them;
+    // taking the representative row could misstate a large merged library.
+    ["Mean MapQ", "Mean BaseQ"].forEach((c) => {
+      let weighted = 0,
+        weight = 0;
+      contrib.forEach((r) => {
+        const v = parseFloat(r[c]);
+        if (isNaN(v)) return;
+        const w = Math.max(0, num(r["# Reads Aligned"]));
+        weighted += v * w;
+        weight += w;
+      });
+      if (weight > 0) merged[c] = weighted / weight;
+    });
+    // Recompute normalized abundance against the full merged specimen, not
+    // whichever member happened to have the highest TASS score.
+    const specimenMembers =
+      typeof specimenGroups === "function" && specimenGroups().has(g.spec)
+        ? specimenGroups().get(g.spec).slice()
+        : members;
+    const activeMembers = specimenMembers.filter((s) => !sampleHidden[s]);
+    const inputReads = activeMembers.reduce(
+      (s, sample) => s + (parseFloat(((typeof SAMPLE_META !== "undefined" && SAMPLE_META[sample]) || {}).total_reads) || 0),
+      0,
+    );
+    const classifiedReads = activeMembers.reduce(
+      (s, sample) =>
+        s + (parseFloat(((typeof SAMPLE_META !== "undefined" && SAMPLE_META[sample]) || {}).total_organism_reads) || 0),
+      0,
+    );
+    const aligned = num(merged["# Reads Aligned"]);
+    if (inputReads > 0) merged["% Reads"] = (aligned / inputReads) * 100;
+    if (classifiedReads > 0) {
+      merged["RPM"] = (aligned / classifiedReads) * 1000000;
+      const genomeKb = num(merged["Genome Length (bp)"]) / 1000;
+      if (genomeKb > 0) merged["RPKM"] = merged["RPM"] / genomeKb;
+    }
+    if (contrib.some((r) => isTruthy(r["High Consequence"]))) merged["High Consequence"] = true;
+    if (contrib.some((r) => isTruthy(r["Passes Threshold"]))) merged["Passes Threshold"] = true;
+    const mts = new Set(contrib.map((r) => (r["Mol Type"] || "").toLowerCase()).filter(Boolean));
+    if (mts.size > 1) merged["Mol Type"] = "both";
+    merged.__merged = true;
+    merged.__mergedFrom = members;
+    merged.__specimenMembers = specimenMembers;
+    merged.__mergedCount = specimenMembers.length;
+    out.push(merged);
+  });
+  return out;
+}
+function _sameOrgLevel(a, b) {
+  const ka = (a["Taxonomic ID #"] || a["Detected Organism"] || "").toString();
+  const kb = (b["Taxonomic ID #"] || b["Detected Organism"] || "").toString();
+  return ka === kb && (a["Level"] || "Strain") === (b["Level"] || "Strain") && (a["Subkey"] || "") === (b["Subkey"] || "");
 }
 
 /* Return a shallow copy of row r with TASS Score + Coverage scaled ×100
@@ -353,11 +515,21 @@ function showTip(html, event) {
   moveTip(event);
 }
 function moveTip(event) {
-  const x = event.clientX + 12,
-    y = event.clientY - 28;
-  // offsetWidth after parking at 0,0 (or from previous frame) is reliable.
+  const x = event.clientX + 12;
+  const cy = event.clientY;
+  const GAP = 14; // clearance from the cursor so the box never straddles it
+  // offsetWidth/Height after parking at 0,0 (or from previous frame) is reliable.
   const tw = tooltip.offsetWidth || 520;
   const th = tooltip.offsetHeight || 0;
+  // Prefer placing the tooltip fully ABOVE the cursor (its old spot) — but only
+  // when it actually fits there. A short tooltip (a couple lines) still ends up
+  // near the old y-28 position; a tall one (e.g. a merged-specimen table listing
+  // every member sample) used to have its bulk render BELOW the cursor instead,
+  // covering the exact heatmap cell/row being hovered. Flip to below the cursor
+  // whenever there isn't room above, so the box always clears the pointer
+  // entirely rather than overlapping it.
+  const fitsAbove = cy - GAP - th >= 4;
+  const y = fitsAbove ? cy - GAP - th : cy + GAP;
   const left = Math.min(x, window.innerWidth - tw - 16);
   const top = Math.min(Math.max(y, 4), window.innerHeight - th - 8);
   tooltip.style.left = left + "px";
@@ -1618,10 +1790,14 @@ function _esc(s) {
 function _pdfKpiCards() {
   const fd = typeof filteredData === "function" ? filteredData() : [];
   const samples = uniq(fd.map((r) => r["Specimen ID"] || "")).filter(Boolean);
-  const totalInput = samples.reduce((s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_reads) || 0), 0);
-  const totalOrg =
-    samples.reduce((s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_organism_reads) || 0), 0) ||
-    fd.reduce((s, r) => s + (parseFloat(r["# Reads Aligned"]) || 0), 0);
+  const metaFor = (sn) =>
+    typeof _summaryMetaFor === "function" ? _summaryMetaFor(sn, fd) : SAMPLE_META[sn] || {};
+  const totalInput = samples.reduce((s, sn) => s + (parseFloat(metaFor(sn).total_reads) || 0), 0);
+  const totalInputUnfiltered = Object.keys(SAMPLE_META || {}).reduce(
+    (s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_reads) || 0),
+    0,
+  );
+  const totalOrg = fd.reduce((s, r) => s + (parseFloat(r["# Reads Aligned"]) || 0), 0);
   let pctClass = totalInput > 0 ? ((totalOrg / totalInput) * 100).toFixed(1) + "%" : "N/A";
   if (pctClass === "0.0%" && totalOrg > 0) pctClass = "<0.1%";
   const uniqOrgs = new Set(fd.map((r) => r["Taxonomic ID #"] || "").filter(Boolean)).size;
@@ -1629,7 +1805,7 @@ function _pdfKpiCards() {
   const hcCount = new Set(
     fd.filter((r) => isTruthy(r["High Consequence"])).map((r) => r["Taxonomic ID #"] || r["Detected Organism"]),
   ).size;
-  const platforms = uniq(samples.map((sn) => (SAMPLE_META[sn] || {}).platform).filter((p) => p && p !== "unknown"));
+  const platforms = uniq(samples.map((sn) => metaFor(sn).platform).filter((p) => p && p !== "unknown"));
   const cut = _tassCutoffSummary();
   let cutVal, cutSub;
   if (cut.mode === "byType" && cut.items.length) {
@@ -1646,11 +1822,15 @@ function _pdfKpiCards() {
     cutVal = cut.global > 0 ? cut.global.toFixed(1) : cut.recommended != null ? cut.recommended.toFixed(1) : "—";
     cutSub = cut.recommended != null && cut.global <= 0 ? "recommended" : "applied filter";
   }
-  const tReads = _fmtBig(totalInput);
   const aReads = _fmtBig(totalOrg);
+  const allReads = _fmtBig(totalInputUnfiltered);
   return [
     { label: "Samples", value: samples.length, sub: platforms.length ? platforms.join(", ") : "in report" },
-    { label: "Total Reads", value: totalInput > 0 ? tReads.short : "N/A", sub: "input reads" },
+    {
+      label: "Total Reads",
+      value: allReads.short,
+      sub: "aligned + unaligned, without filters",
+    },
     { label: "% Classified", value: pctClass, sub: aReads.short + " aligned" },
     { label: "Organisms", value: _fmtInt(uniqOrgs), sub: "unique taxa" },
     { label: "Genera", value: _fmtInt(uniqGenera), sub: "unique genera" },

--- a/assets/src/js/03_sample_sidebar.js
+++ b/assets/src/js/03_sample_sidebar.js
@@ -28,9 +28,17 @@ function _deleteSampleData(id) {
   Object.keys(PROT || {}).forEach((k) => {
     if (!Array.isArray(PROT[k])) return;
     for (let i = PROT[k].length - 1; i >= 0; i--) {
-      if (PROT[k][i] && PROT[k][i]["Specimen ID"] === id) PROT[k].splice(i, 1);
+      const r = PROT[k][i];
+      if (r && (r["Specimen ID"] === id || r.Sample === id || r.sample === id)) PROT[k].splice(i, 1);
     }
   });
+  // Novelty-only samples are another authoritative source for the sidebar.
+  // Remove the payload and any per-sample download links before rebuilding.
+  if (NOVELTY && NOVELTY.samples) delete NOVELTY.samples[id];
+  for (let i = NOVELTY_DL.length - 1; i >= 0; i--) {
+    const d = NOVELTY_DL[i] || {};
+    if (d.sample === id || d.label === id || String(d.filename || "").startsWith(id + ".")) NOVELTY_DL.splice(i, 1);
+  }
   // Prune BOOT in place — the source of resurrection on subsequent
   // file drops if we don't filter it here.
   if (BOOT) {
@@ -48,11 +56,28 @@ function _deleteSampleData(id) {
       Object.keys(BOOT.prot_data).forEach((k) => {
         if (!Array.isArray(BOOT.prot_data[k])) return;
         for (let i = BOOT.prot_data[k].length - 1; i >= 0; i--) {
-          if (BOOT.prot_data[k][i] && BOOT.prot_data[k][i]["Specimen ID"] === id) {
+          const r = BOOT.prot_data[k][i];
+          if (r && (r["Specimen ID"] === id || r.Sample === id || r.sample === id)) {
             BOOT.prot_data[k].splice(i, 1);
           }
         }
       });
+    }
+    if (Array.isArray(BOOT.run_metadata_records)) {
+      for (let i = BOOT.run_metadata_records.length - 1; i >= 0; i--) {
+        if (BOOT.run_metadata_records[i] && BOOT.run_metadata_records[i].sample_name === id) {
+          BOOT.run_metadata_records.splice(i, 1);
+        }
+      }
+    }
+    if (BOOT.novelty && BOOT.novelty.samples) delete BOOT.novelty.samples[id];
+    if (Array.isArray(BOOT.novelty_downloads) && BOOT.novelty_downloads !== NOVELTY_DL) {
+      for (let i = BOOT.novelty_downloads.length - 1; i >= 0; i--) {
+        const d = BOOT.novelty_downloads[i] || {};
+        if (d.sample === id || d.label === id || String(d.filename || "").startsWith(id + ".")) {
+          BOOT.novelty_downloads.splice(i, 1);
+        }
+      }
     }
   }
   // Drop this sample from accumulated upload state too
@@ -61,6 +86,7 @@ function _deleteSampleData(id) {
   delete sampleHidden[id];
   delete sampleRescale[id];
   _sampleOrder = _sampleOrder.filter((s) => s !== id);
+  if (typeof SPECIMEN_OVERRIDE !== "undefined") delete SPECIMEN_OVERRIDE[id];
   // Re-evaluate VF/AMR tab visibility after the prune
   HAS_PROT = Object.keys(PROT || {}).some((k) => Array.isArray(PROT[k]) && PROT[k].length > 0);
   const protBtn = document.getElementById("prot-tab-btn");
@@ -68,9 +94,19 @@ function _deleteSampleData(id) {
   // Re-evaluate histogram tab visibility too
   const histBtn = document.getElementById("hist-tab-btn");
   if (histBtn) histBtn.classList.toggle("hidden", CONTIG_DATA.length === 0);
-  // Prune SAMPLE_META so % classified drops the deleted sample's reads
+  // Prune metadata BEFORE buildSampleList(): _allSampleIds() intentionally
+  // treats metadata as authoritative, so rebuilding first left a ghost row.
   delete SAMPLE_META[id];
   if (BOOT && BOOT.sample_meta) delete BOOT.sample_meta[id];
+  if (typeof SPECIMEN_META_RESOLVED !== "undefined" && typeof specimenGroups === "function") {
+    Object.keys(SPECIMEN_META_RESOLVED).forEach((spec) => {
+      const members = specimenGroups().get(spec) || [];
+      if (members.length < 2) delete SPECIMEN_META_RESOLVED[spec];
+    });
+  }
+  HAS_NOVELTY = !!(NOVELTY && NOVELTY.samples && Object.keys(NOVELTY.samples).length);
+  const noveltyBtn = document.getElementById("novelty-tab-btn");
+  if (noveltyBtn) noveltyBtn.classList.toggle("hidden", !HAS_NOVELTY);
   buildSampleList();
   buildTable();
   _rebuildMapMarkers();
@@ -80,7 +116,7 @@ function _deleteSampleData(id) {
 }
 
 function removeAllSamples() {
-  const samples = uniq(DATA.map((r) => r["Specimen ID"] || "")).filter(Boolean);
+  const samples = Array.from(_allSampleIds()).filter(Boolean);
   if (!samples.length) return;
   const ok = confirm(
     `Permanently delete all ${samples.length} sample${
@@ -96,11 +132,21 @@ function removeAllSamples() {
   DATA.length = 0;
   RUN_META.length = 0;
   CONTIG_DATA.length = 0;
+  if (NOVELTY && NOVELTY.samples) Object.keys(NOVELTY.samples).forEach((k) => delete NOVELTY.samples[k]);
+  NOVELTY_DL.length = 0;
+  HAS_NOVELTY = false;
+  const noveltyBtn = document.getElementById("novelty-tab-btn");
+  if (noveltyBtn) noveltyBtn.classList.add("hidden");
   if (typeof _invalidateSummaryHistMap === "function") _invalidateSummaryHistMap();
   // Reset BOOT in place so all references see the change.
   if (BOOT) {
     if (Array.isArray(BOOT.records)) BOOT.records.length = 0;
     if (Array.isArray(BOOT.contig_data)) BOOT.contig_data.length = 0;
+    if (Array.isArray(BOOT.run_metadata_records)) BOOT.run_metadata_records.length = 0;
+    if (BOOT.novelty && BOOT.novelty.samples) {
+      Object.keys(BOOT.novelty.samples).forEach((k) => delete BOOT.novelty.samples[k]);
+    }
+    if (Array.isArray(BOOT.novelty_downloads)) BOOT.novelty_downloads.length = 0;
     if (BOOT.prot_data && typeof BOOT.prot_data === "object") {
       Object.keys(BOOT.prot_data).forEach((k) => {
         if (Array.isArray(BOOT.prot_data[k])) BOOT.prot_data[k].length = 0;
@@ -124,6 +170,12 @@ function removeAllSamples() {
     delete sampleRescale[id];
   });
   _sampleOrder = [];
+  if (typeof SPECIMEN_OVERRIDE !== "undefined") {
+    Object.keys(SPECIMEN_OVERRIDE).forEach((k) => delete SPECIMEN_OVERRIDE[k]);
+  }
+  if (typeof SPECIMEN_META_RESOLVED !== "undefined") {
+    Object.keys(SPECIMEN_META_RESOLVED).forEach((k) => delete SPECIMEN_META_RESOLVED[k]);
+  }
   // Clear SAMPLE_META so % classified resets to N/A with no data
   Object.keys(SAMPLE_META).forEach((k) => delete SAMPLE_META[k]);
   if (BOOT && BOOT.sample_meta) Object.keys(BOOT.sample_meta).forEach((k) => delete BOOT.sample_meta[k]);
@@ -223,6 +275,84 @@ function _allSampleIds() {
 // scores can be unreliable, so the row gets a warning icon. Returns a
 // {warn, msg} object; warn=false means the sample looks fine.
 const _LOW_READ_THRESHOLD = 1000; // total reads below this == "few reads"
+let _sampleListPage = 0;
+let _sampleListPageIds = [];
+
+function _sampleListFilteredOrder() {
+  const input = document.getElementById("sample-list-search");
+  const q = String((input && input.value) || "").trim().toLowerCase();
+  if (!q) return _sampleOrder.slice();
+  return _sampleOrder.filter((id) => {
+    const specimen =
+      typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled && typeof specimenOf === "function"
+        ? specimenOf(id)
+        : "";
+    return id.toLowerCase().includes(q) || (specimen && specimen.toLowerCase().includes(q));
+  });
+}
+
+function _wireSampleListTools() {
+  const search = document.getElementById("sample-list-search");
+  const size = document.getElementById("sample-list-page-size");
+  const prev = document.getElementById("sample-list-prev");
+  const next = document.getElementById("sample-list-next");
+  if (search && !search._wired) {
+    search._wired = true;
+    search.addEventListener("input", () => {
+      _sampleListPage = 0;
+      buildSampleList();
+    });
+  }
+  if (size && !size._wired) {
+    size._wired = true;
+    size.addEventListener("change", () => {
+      _sampleListPage = 0;
+      buildSampleList();
+    });
+  }
+  if (prev && !prev._wired) {
+    prev._wired = true;
+    prev.addEventListener("click", () => {
+      if (_sampleListPage > 0) {
+        _sampleListPage--;
+        buildSampleList();
+      }
+    });
+  }
+  if (next && !next._wired) {
+    next._wired = true;
+    next.addEventListener("click", () => {
+      const perPage = parseInt((size || {}).value, 10) || 25;
+      const pages = Math.max(1, Math.ceil(_sampleListFilteredOrder().length / perPage));
+      if (_sampleListPage + 1 < pages) {
+        _sampleListPage++;
+        buildSampleList();
+      }
+    });
+  }
+}
+
+function _updateSampleListTools(filteredCount, totalCount, pages) {
+  const info = document.getElementById("sample-list-page-info");
+  const match = document.getElementById("sample-list-match-info");
+  const prev = document.getElementById("sample-list-prev");
+  const next = document.getElementById("sample-list-next");
+  if (info) info.textContent = `${_sampleListPage + 1} / ${pages}`;
+  if (match) {
+    const start = filteredCount ? _sampleListPageIds.length ? _sampleListPage * (parseInt((document.getElementById("sample-list-page-size") || {}).value, 10) || 25) + 1 : 0 : 0;
+    const end = filteredCount ? start + _sampleListPageIds.length - 1 : 0;
+    match.textContent = filteredCount === totalCount ? `${start}–${end} of ${totalCount} samples` : `${start}–${end} of ${filteredCount} matches · ${totalCount} total`;
+  }
+  if (prev) {
+    prev.disabled = _sampleListPage <= 0;
+    prev.style.opacity = prev.disabled ? "0.35" : "1";
+  }
+  if (next) {
+    next.disabled = _sampleListPage + 1 >= pages;
+    next.style.opacity = next.disabled ? "0.35" : "1";
+  }
+}
+
 function _sampleDataWarning(id) {
   const meta = SAMPLE_META[id] || {};
   const totalReads = parseInt(meta.total_reads) || 0;
@@ -266,17 +396,37 @@ function buildSampleList() {
   const cont = document.getElementById("sample-list");
   if (!cont) return;
   cont.innerHTML = "";
+  _wireSampleListTools();
+  const filteredOrder = _sampleListFilteredOrder();
+  const pageSize = parseInt((document.getElementById("sample-list-page-size") || {}).value, 10) || 25;
+  const pages = Math.max(1, Math.ceil(filteredOrder.length / pageSize));
+  _sampleListPage = Math.max(0, Math.min(_sampleListPage, pages - 1));
+  _sampleListPageIds = filteredOrder.slice(_sampleListPage * pageSize, (_sampleListPage + 1) * pageSize);
+  _updateSampleListTools(filteredOrder.length, _sampleOrder.length, pages);
 
   // ── drag state ──────────────────────────────────────────────────────
   let _dragSrc = null;
 
   function _rebuildFromDOM() {
     const rows = cont.querySelectorAll(".sample-entry[data-sid]");
-    _sampleOrder = Array.from(rows).map((r) => r.dataset.sid);
+    const rendered = Array.from(rows).map((r) => r.dataset.sid);
+    const renderedSet = new Set(rendered);
+    let i = 0;
+    // Replace only the slots represented on this page. Samples on other pages
+    // and nonmatching search results keep their positions in the global order.
+    _sampleOrder = _sampleOrder.map((id) => (renderedSet.has(id) ? rendered[i++] : id));
+    if (
+      typeof specimenMergeEnabled !== "undefined" &&
+      specimenMergeEnabled &&
+      window.specimenMerge &&
+      typeof window.specimenMerge.refreshBar === "function"
+    ) {
+      window.specimenMerge.refreshBar();
+    }
     redraw();
   }
 
-  _sampleOrder.forEach((id) => {
+  _sampleListPageIds.forEach((id) => {
     const div = document.createElement("div");
     div.className = "sample-entry";
     div.dataset.sid = id;
@@ -486,6 +636,9 @@ function buildSampleList() {
   buildPerTypeTassUI();
   // Update the sidebar legend (sample swatches + TASS cutoffs)
   _updateSidebarLegend();
+  if (window.specimenMerge && typeof window.specimenMerge.refreshBar === "function") {
+    window.specimenMerge.refreshBar();
+  }
 }
 
 /** Rebuild the sidebar legend: sample color swatches + active TASS cutoffs.
@@ -499,9 +652,9 @@ function _updateSidebarLegend() {
   // ── sample swatches ──────────────────────────────────────────────
   if (_sampleOrder.length > 0) {
     let swatchHtml =
-      '<div style="font-size:0.72em;font-weight:600;color:#546e7a;margin-bottom:0.25em">Sample Colors</div>';
+      `<div style="font-size:0.72em;font-weight:600;color:#546e7a;margin-bottom:0.25em">Sample Colors <span style="font-weight:400;color:#90a4ae">(current page)</span></div>`;
     swatchHtml += '<div style="display:flex;flex-direction:column;gap:0.18em">';
-    _sampleOrder.forEach((id) => {
+    _sampleListPageIds.forEach((id) => {
       const col = sampleColors[id] || "#888";
       const hidden = sampleHidden[id];
       swatchHtml +=
@@ -510,6 +663,9 @@ function _updateSidebarLegend() {
         `<span style="font-size:0.78em;color:#37474f;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:130px" title="${id}">${id}</span>` +
         `</div>`;
     });
+    if (!_sampleListPageIds.length) {
+      swatchHtml += '<div style="font-size:0.75em;color:#90a4ae;font-style:italic">No matching samples.</div>';
+    }
     swatchHtml += "</div>";
     samplesEl.innerHTML = swatchHtml;
     panel.style.display = "";

--- a/assets/src/js/03_sample_sidebar.js
+++ b/assets/src/js/03_sample_sidebar.js
@@ -280,7 +280,9 @@ let _sampleListPageIds = [];
 
 function _sampleListFilteredOrder() {
   const input = document.getElementById("sample-list-search");
-  const q = String((input && input.value) || "").trim().toLowerCase();
+  const q = String((input && input.value) || "")
+    .trim()
+    .toLowerCase();
   if (!q) return _sampleOrder.slice();
   return _sampleOrder.filter((id) => {
     const specimen =
@@ -339,9 +341,16 @@ function _updateSampleListTools(filteredCount, totalCount, pages) {
   const next = document.getElementById("sample-list-next");
   if (info) info.textContent = `${_sampleListPage + 1} / ${pages}`;
   if (match) {
-    const start = filteredCount ? _sampleListPageIds.length ? _sampleListPage * (parseInt((document.getElementById("sample-list-page-size") || {}).value, 10) || 25) + 1 : 0 : 0;
+    const start = filteredCount
+      ? _sampleListPageIds.length
+        ? _sampleListPage * (parseInt((document.getElementById("sample-list-page-size") || {}).value, 10) || 25) + 1
+        : 0
+      : 0;
     const end = filteredCount ? start + _sampleListPageIds.length - 1 : 0;
-    match.textContent = filteredCount === totalCount ? `${start}–${end} of ${totalCount} samples` : `${start}–${end} of ${filteredCount} matches · ${totalCount} total`;
+    match.textContent =
+      filteredCount === totalCount
+        ? `${start}–${end} of ${totalCount} samples`
+        : `${start}–${end} of ${filteredCount} matches · ${totalCount} total`;
   }
   if (prev) {
     prev.disabled = _sampleListPage <= 0;
@@ -651,8 +660,7 @@ function _updateSidebarLegend() {
 
   // ── sample swatches ──────────────────────────────────────────────
   if (_sampleOrder.length > 0) {
-    let swatchHtml =
-      `<div style="font-size:0.72em;font-weight:600;color:#546e7a;margin-bottom:0.25em">Sample Colors <span style="font-weight:400;color:#90a4ae">(current page)</span></div>`;
+    let swatchHtml = `<div style="font-size:0.72em;font-weight:600;color:#546e7a;margin-bottom:0.25em">Sample Colors <span style="font-weight:400;color:#90a4ae">(current page)</span></div>`;
     swatchHtml += '<div style="display:flex;flex-direction:column;gap:0.18em">';
     _sampleListPageIds.forEach((id) => {
       const col = sampleColors[id] || "#888";

--- a/assets/src/js/05_tab_heatmap.js
+++ b/assets/src/js/05_tab_heatmap.js
@@ -162,20 +162,20 @@ function drawHeatmap() {
       });
 
     // Draw circle badge on the right if mol_type is set
-    if (mt === "dna" || mt === "rna") {
+    if (mt === "dna" || mt === "rna" || mt === "both") {
       const cy = yScale(org) + yScale.bandwidth() / 2;
-      const badgeColor = mt === "dna" ? "#1565c0" : "#6a1b9a";
-      const badgeLetter = mt === "dna" ? "D" : "R";
+      const badgeColor = mt === "dna" ? "#1565c0" : mt === "rna" ? "#6a1b9a" : "#455a64";
+      const badgeLetter = mt === "dna" ? "D" : mt === "rna" ? "R" : "D+R";
       const badgeG = mtBadgeGroup
         .append("g")
         .attr("transform", `translate(${_mtBadgeX + 7}, ${cy})`)
-        .attr("title", mt === "dna" ? "DNA pathogen" : "RNA pathogen");
-      badgeG.append("circle").attr("r", 7).attr("fill", badgeColor).attr("opacity", 0.9);
+        .attr("title", mt === "dna" ? "DNA pathogen" : mt === "rna" ? "RNA pathogen" : "Merged DNA + RNA evidence");
+      badgeG.append("circle").attr("r", mt === "both" ? 9 : 7).attr("fill", badgeColor).attr("opacity", 0.9);
       badgeG
         .append("text")
         .attr("text-anchor", "middle")
         .attr("dominant-baseline", "central")
-        .attr("font-size", 7)
+        .attr("font-size", mt === "both" ? 5.5 : 7)
         .attr("font-weight", "bold")
         .attr("fill", "#fff")
         .attr("pointer-events", "none")

--- a/assets/src/js/05_tab_heatmap.js
+++ b/assets/src/js/05_tab_heatmap.js
@@ -170,7 +170,11 @@ function drawHeatmap() {
         .append("g")
         .attr("transform", `translate(${_mtBadgeX + 7}, ${cy})`)
         .attr("title", mt === "dna" ? "DNA pathogen" : mt === "rna" ? "RNA pathogen" : "Merged DNA + RNA evidence");
-      badgeG.append("circle").attr("r", mt === "both" ? 9 : 7).attr("fill", badgeColor).attr("opacity", 0.9);
+      badgeG
+        .append("circle")
+        .attr("r", mt === "both" ? 9 : 7)
+        .attr("fill", badgeColor)
+        .attr("opacity", 0.9);
       badgeG
         .append("text")
         .attr("text-anchor", "middle")

--- a/assets/src/js/10_tab_proteins_vfamr.js
+++ b/assets/src/js/10_tab_proteins_vfamr.js
@@ -60,14 +60,17 @@ function drawProtGenus() {
 
   if (hasByRow) {
     const _pgFdPairs = new Set(filteredData().map((r) => `${r["Specimen ID"]}||${r["Genus"] || "Unknown"}`));
+    const _pgPair = (r) => {
+      const raw = r["Specimen ID"] || "";
+      const sample = typeof specimenKey === "function" ? specimenKey(raw) : raw;
+      return `${sample}||${r["Genus"] || "Unknown"}`;
+    };
     const visibleHits = [
       ...(PROT.per_gene_hits || []).filter(
-        (r) => !sampleHidden[r["Specimen ID"]] && _pgFdPairs.has(`${r["Specimen ID"]}||${r["Genus"] || "Unknown"}`),
+        (r) => !sampleHidden[r["Specimen ID"]] && _pgFdPairs.has(_pgPair(r)),
       ),
       ...(PROT.amr_genes || [])
-        .filter(
-          (r) => !sampleHidden[r["Specimen ID"]] && _pgFdPairs.has(`${r["Specimen ID"]}||${r["Genus"] || "Unknown"}`),
-        )
+        .filter((r) => !sampleHidden[r["Specimen ID"]] && _pgFdPairs.has(_pgPair(r)))
         .map((r) => ({ ...r, Property: r["Property"] || r["Class"] })),
     ];
     visibleHits.forEach((r) => {
@@ -308,14 +311,17 @@ function drawProtProperty() {
   wrap.innerHTML = "";
 
   const _ppFdPairs = new Set(filteredData().map((r) => `${r["Specimen ID"]}||${r["Genus"] || "Unknown"}`));
+  const _ppPair = (r) => {
+    const raw = r["Specimen ID"] || "";
+    const sample = typeof specimenKey === "function" ? specimenKey(raw) : raw;
+    return `${sample}||${r["Genus"] || "Unknown"}`;
+  };
   const _allHits = [
     ...(PROT.per_gene_hits || []).filter(
-      (r) => !sampleHidden[r["Specimen ID"]] && _ppFdPairs.has(`${r["Specimen ID"]}||${r["Genus"] || "Unknown"}`),
+      (r) => !sampleHidden[r["Specimen ID"]] && _ppFdPairs.has(_ppPair(r)),
     ),
     ...(PROT.amr_genes || [])
-      .filter(
-        (r) => !sampleHidden[r["Specimen ID"]] && _ppFdPairs.has(`${r["Specimen ID"]}||${r["Genus"] || "Unknown"}`),
-      )
+      .filter((r) => !sampleHidden[r["Specimen ID"]] && _ppFdPairs.has(_ppPair(r)))
       .map((r) => ({ ...r, _source: "AMR" })),
   ];
   const _propGenus = {};
@@ -686,7 +692,15 @@ function _dedupRows(rows) {
         .filter((r) => !sampleHidden[r["Specimen ID"]] && (!r["Specimen ID"] || sampleSet.has(r["Specimen ID"])))
         .map((r) => ({ ...r, _source: "AMR" })),
     );
-    _protAllRows = _dedupRows([...geneRows, ...amrRows]);
+    // When specimen merge is on, relabel each hit's Specimen ID onto its
+    // specimen group before deduping so members of the same specimen collapse
+    // into one row instead of listing every raw sample name separately.
+    const _relabel = (r) => {
+      if (typeof specimenKey !== "function" || !r["Specimen ID"]) return r;
+      const grouped = specimenKey(r["Specimen ID"]);
+      return grouped === r["Specimen ID"] ? r : { ...r, "Specimen ID": grouped };
+    };
+    _protAllRows = _dedupRows([...geneRows.map(_relabel), ...amrRows.map(_relabel)]);
     if (!_protAllRows.length) {
       document.getElementById("prot-table-wrap").style.display = "none";
       return;

--- a/assets/src/js/10_tab_proteins_vfamr.js
+++ b/assets/src/js/10_tab_proteins_vfamr.js
@@ -66,9 +66,7 @@ function drawProtGenus() {
       return `${sample}||${r["Genus"] || "Unknown"}`;
     };
     const visibleHits = [
-      ...(PROT.per_gene_hits || []).filter(
-        (r) => !sampleHidden[r["Specimen ID"]] && _pgFdPairs.has(_pgPair(r)),
-      ),
+      ...(PROT.per_gene_hits || []).filter((r) => !sampleHidden[r["Specimen ID"]] && _pgFdPairs.has(_pgPair(r))),
       ...(PROT.amr_genes || [])
         .filter((r) => !sampleHidden[r["Specimen ID"]] && _pgFdPairs.has(_pgPair(r)))
         .map((r) => ({ ...r, Property: r["Property"] || r["Class"] })),
@@ -317,9 +315,7 @@ function drawProtProperty() {
     return `${sample}||${r["Genus"] || "Unknown"}`;
   };
   const _allHits = [
-    ...(PROT.per_gene_hits || []).filter(
-      (r) => !sampleHidden[r["Specimen ID"]] && _ppFdPairs.has(_ppPair(r)),
-    ),
+    ...(PROT.per_gene_hits || []).filter((r) => !sampleHidden[r["Specimen ID"]] && _ppFdPairs.has(_ppPair(r))),
     ...(PROT.amr_genes || [])
       .filter((r) => !sampleHidden[r["Specimen ID"]] && _ppFdPairs.has(_ppPair(r)))
       .map((r) => ({ ...r, _source: "AMR" })),

--- a/assets/src/js/12_tab_histogram.js
+++ b/assets/src/js/12_tab_histogram.js
@@ -20,7 +20,15 @@
       // Keep rows with no numeric strain TASS (nothing to gate on), else
       // require a strict own-level pass.
       if (pi && !isNaN(pi.strain) && !pi.strainPass) return;
-      set.add(`${r["Specimen ID"]}||${r["Taxonomic ID #"]}`);
+      const tax = r["Taxonomic ID #"];
+      set.add(`${r["Specimen ID"]}||${tax}`);
+      // Merged-specimen rows carry the specimen NAME in "Specimen ID", but
+      // CONTIG_DATA is keyed by the original member samples. Add each member's
+      // key too, otherwise the gate rejects every CONTIG_DATA entry and the
+      // Histogram tab renders empty when merge is on.
+      if (Array.isArray(r.__mergedFrom)) {
+        r.__mergedFrom.forEach((s) => set.add(`${s}||${tax}`));
+      }
     });
     return set;
   }
@@ -88,9 +96,15 @@
 
     function _refreshSamples() {
       const orgKey = orgSel.value;
+      const prev = sampleSel.value;
       sampleSel.innerHTML = '<option value="">All samples</option>';
       const rx = _getTextFilter();
       const visibleTaxa = _histPassingTaxa();
+      const mergeOn =
+        typeof specimenMergeEnabled !== "undefined" &&
+        specimenMergeEnabled &&
+        typeof specimenOf === "function";
+      const choices = new Map();
       CONTIG_DATA.filter(
         (cd) =>
           _getOrgKey(cd) === orgKey &&
@@ -99,12 +113,25 @@
           cd.contigs &&
           cd.contigs.length,
       ).forEach((cd) => {
-        if (rx && !rx.test(cd.organism || "") && !rx.test(cd.sample || "")) return;
+        const sample = mergeOn ? specimenOf(cd.sample) : cd.sample;
+        if (rx && !rx.test(cd.organism || "") && !rx.test(cd.sample || "") && !rx.test(sample || "")) return;
+        if (choices.has(sample)) return;
+        const members =
+          mergeOn && typeof specimenGroups === "function" ? specimenGroups().get(sample) || [cd.sample] : [cd.sample];
+        choices.set(sample, members.length > 1 ? `${sample} (${members.length} samples)` : sample);
+      });
+      choices.forEach((label, sample) => {
         const opt = document.createElement("option");
-        opt.value = cd.sample;
-        opt.textContent = cd.sample;
+        opt.value = sample;
+        opt.textContent = label;
         sampleSel.appendChild(opt);
       });
+      if (prev && Array.from(sampleSel.options).some((o) => o.value === prev)) {
+        sampleSel.value = prev;
+      } else if (mergeOn && prev) {
+        const mergedPrev = specimenOf(prev);
+        if (Array.from(sampleSel.options).some((o) => o.value === mergedPrev)) sampleSel.value = mergedPrev;
+      }
     }
 
     _refreshOrgs();
@@ -153,6 +180,31 @@
   // Persistent filter state across drawHistogram calls
   let histSelectedContig = null;
   let _histLastOrgKey = null;
+  // Last specimen-merge fingerprint the selectors were built against. When the
+  // merge toggle flips or a specimen grouping is edited, this changes and we
+  // rebuild the org/sample dropdowns so the tab reflects the new grouping.
+  let _histLastMergeFp = null;
+
+  // Merge one contig list per name across member samples: reads summed, the
+  // rest taken as the max (they describe the same reference contig).
+  function _mergeContigsByName(cdsList) {
+    const byName = new Map();
+    cdsList.forEach((cd) =>
+      (cd.contigs || []).forEach((c) => {
+        const ex = byName.get(c.name);
+        if (!ex) {
+          byName.set(c.name, Object.assign({}, c));
+          return;
+        }
+        ex.reads = num(ex.reads) + num(c.reads);
+        ex.covered_bases = Math.max(num(ex.covered_bases), num(c.covered_bases));
+        ex.coverage = Math.max(num(ex.coverage), num(c.coverage));
+        ex.mean_depth = Math.max(num(ex.mean_depth), num(c.mean_depth));
+        ex.length = Math.max(num(ex.length), num(c.length));
+      }),
+    );
+    return Array.from(byName.values());
+  }
 
   window.drawHistogram = function () {
     const chartWrap = document.getElementById("hist-chart-wrap");
@@ -170,6 +222,23 @@
     const metricSel = document.getElementById("hist-metric-sel");
     const top20El = document.getElementById("hist-top20");
     if (!orgSel) return;
+
+    // Rebuild the selectors when the specimen grouping changed since the last
+    // draw (merge toggled on/off, or a live regrouping). Without this the tab
+    // keeps stale per-sample or per-specimen options after grouping.
+    const _mergeFp = typeof _hashSpecimenMerge === "function" ? _hashSpecimenMerge() : "";
+    if (_mergeFp !== _histLastMergeFp) {
+      _histLastMergeFp = _mergeFp;
+      _buildSelectors();
+    }
+
+    // Show the "Merged view" control only when a specimen grouping is active.
+    const _mergeOn = typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled;
+    const _grouped = _mergeOn && typeof hasSpecimenGrouping === "function" && hasSpecimenGrouping();
+    const _mmLabel = document.getElementById("hist-merge-mode-label");
+    const _mmSel = document.getElementById("hist-merge-mode-sel");
+    if (_mmLabel) _mmLabel.style.display = _grouped ? "" : "none";
+    if (_mmSel) _mmSel.style.display = _grouped ? "" : "none";
 
     const orgKey = orgSel.value;
     // Reset per-contig filter when the organism changes
@@ -191,7 +260,11 @@
     let entries = CONTIG_DATA.filter(
       (cd) => _getOrgKey(cd) === orgKey && !sampleHidden[cd.sample] && _fdTaxaKeys.has(`${cd.sample}||${cd.taxon_id}`),
     );
-    if (sample) entries = entries.filter((cd) => cd.sample === sample);
+    if (sample) {
+      entries = entries.filter((cd) =>
+        _grouped && typeof specimenOf === "function" ? specimenOf(cd.sample) === sample : cd.sample === sample,
+      );
+    }
     // Sort entries to match the user-defined sample order from the main panel
     if (_sampleOrder.length) {
       const _idx = Object.fromEntries(_sampleOrder.map((id, i) => [id, i]));
@@ -201,11 +274,53 @@
         return ia - ib;
       });
     }
+    // ── Merged view: combine each specimen's member samples into one breadth
+    // curve + pooled depth for organisms hit in 2+ members. The curve is the
+    // EXACT positional union when the report carries covered_intervals (label
+    // "combined union"), otherwise a per-bin max lower bound (label "combined
+    // max") — see _covCombineCds. Falls back to per-sample rows when member
+    // profiles have different references, or when the user picks "Per sample".
+    // Applies to All samples or to one selected specimen; a selected specimen
+    // is filtered to its raw members above before those members are combined. ──
+    const _mmMode = (_mmSel && _mmSel.value) || "overlay";
+    if (_grouped && _mmMode === "combined" && typeof _covCombineCds === "function") {
+      const bySpec = new Map();
+      entries.forEach((cd) => {
+        const spec = typeof specimenOf === "function" ? specimenOf(cd.sample) : cd.sample;
+        if (!bySpec.has(spec)) bySpec.set(spec, []);
+        bySpec.get(spec).push(cd);
+      });
+      const combined = [];
+      bySpec.forEach((cds, spec) => {
+        if (cds.length < 2) {
+          combined.push(cds[0]);
+          return;
+        }
+        const syn = _covCombineCds(cds.map((cd) => ({ sample: cd.sample, cd })));
+        if (syn && syn.__combinable) {
+          const _how = syn.__exactUnion ? "union" : "max";
+          syn.sample = `${spec} · combined ${_how} (${cds.length} libs)`;
+          syn.__mergedMembers = cds.map((c) => c.sample);
+          syn.contigs = _mergeContigsByName(cds);
+          combined.push(syn);
+        } else {
+          // Different references — cannot combine honestly; keep member rows.
+          cds.forEach((cd) => combined.push(cd));
+        }
+      });
+      entries = combined;
+    }
+
     // Always show the sample name in chart titles when the dropdown is
     // on "All samples" — even if just one entry matches. Previously this
     // required `entries.length > 1`, which meant uploaded samples that
     // were the sole match for an organism rendered with no name at all.
-    const showAll = !sample;
+    const selectedMergedSpecimen =
+      _grouped &&
+      sample &&
+      typeof specimenGroups === "function" &&
+      (specimenGroups().get(sample) || []).length > 1;
+    const showAll = !sample || entries.length > 1 || selectedMergedSpecimen;
 
     if (!entries.length || entries.every((cd) => !cd.contigs || !cd.contigs.length)) {
       noData.style.display = "block";
@@ -871,7 +986,7 @@
 
   // Wire histogram controls after DOM is ready (scripts are at end of body)
   _buildSelectors();
-  ["hist-sample-sel", "hist-metric-sel"].forEach((id) => {
+  ["hist-sample-sel", "hist-metric-sel", "hist-merge-mode-sel"].forEach((id) => {
     const el = document.getElementById(id);
     if (el) el.addEventListener("change", window.drawHistogram);
   });
@@ -1018,12 +1133,14 @@ function _renderOneRow(row) {
         contentSpan.appendChild(badge);
       }
       contentSpan.appendChild(document.createTextNode(val));
-      if (mt === "dna" || mt === "rna") {
+      if (mt === "dna" || mt === "rna" || mt === "both") {
         const mtBadge = document.createElement("span");
-        mtBadge.textContent = mt === "dna" ? "D" : "R";
-        mtBadge.title = mt === "dna" ? "DNA pathogen" : "RNA pathogen";
-        mtBadge.style.cssText = `display:inline-flex;align-items:center;justify-content:center;width:14px;height:14px;border-radius:50%;background:${
-          mt === "dna" ? "#1565c0" : "#6a1b9a"
+        mtBadge.textContent = mt === "dna" ? "D" : mt === "rna" ? "R" : "D+R";
+        mtBadge.title = mt === "dna" ? "DNA pathogen" : mt === "rna" ? "RNA pathogen" : "Merged DNA + RNA evidence";
+        mtBadge.style.cssText = `display:inline-flex;align-items:center;justify-content:center;min-width:14px;height:14px;padding:0 ${
+          mt === "both" ? 2 : 0
+        }px;border-radius:7px;background:${
+          mt === "dna" ? "#1565c0" : mt === "rna" ? "#6a1b9a" : "#455a64"
         };color:#fff;font-size:8px;font-weight:700;vertical-align:middle;margin-left:3px;line-height:1;flex-shrink:0`;
         contentSpan.appendChild(mtBadge);
       }
@@ -1076,6 +1193,10 @@ function _renderOneRow(row) {
       pinHint.className = "row-pin-hint";
       rightGroup.appendChild(pinHint);
       td.appendChild(rightGroup);
+    } else if (c === "Specimen ID") {
+      td.appendChild(document.createTextNode(String(val)));
+      const badgeHtml = typeof _mergedSampleBadgeHTML === "function" ? _mergedSampleBadgeHTML(row) : "";
+      if (badgeHtml) td.insertAdjacentHTML("beforeend", badgeHtml);
     } else {
       td.textContent = val;
     }
@@ -1322,7 +1443,11 @@ function populateTable() {
       gr.className = "grp-row";
       const gtd = document.createElement("td");
       gtd.colSpan = visibleCols.length;
-      gtd.innerHTML = `<i class="fas fa-vial"></i> ${_lastGrp}`;
+      const _mergedBadge = typeof _mergedSampleBadgeHTML === "function" ? _mergedSampleBadgeHTML(row) : "";
+      gtd.innerHTML = `<i class="fas fa-vial"></i> ${String(_lastGrp)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")}${_mergedBadge}`;
       gr.appendChild(gtd);
       frag.appendChild(gr);
     }

--- a/assets/src/js/12_tab_histogram.js
+++ b/assets/src/js/12_tab_histogram.js
@@ -1387,7 +1387,7 @@ function populateTable() {
     // Group by Sample: primary sort follows _sampleOrder (right-panel order),
     // secondary sort on the active column (or TASS desc by default) within each group.
     const sc = sortCol || "TASS Score";
-    const _grpIdx = _sampleOrder.length ? Object.fromEntries(_sampleOrder.map((id, i) => [id, i])) : {};
+    const _grpIdx = _sampleOrGroupIndexMap();
     fd = [...fd].sort((a, b) => {
       const sia = String(a["Specimen ID"] || "");
       const sib = String(b["Specimen ID"] || "");

--- a/assets/src/js/12_tab_histogram.js
+++ b/assets/src/js/12_tab_histogram.js
@@ -101,9 +101,7 @@
       const rx = _getTextFilter();
       const visibleTaxa = _histPassingTaxa();
       const mergeOn =
-        typeof specimenMergeEnabled !== "undefined" &&
-        specimenMergeEnabled &&
-        typeof specimenOf === "function";
+        typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled && typeof specimenOf === "function";
       const choices = new Map();
       CONTIG_DATA.filter(
         (cd) =>
@@ -316,10 +314,7 @@
     // required `entries.length > 1`, which meant uploaded samples that
     // were the sole match for an organism rendered with no name at all.
     const selectedMergedSpecimen =
-      _grouped &&
-      sample &&
-      typeof specimenGroups === "function" &&
-      (specimenGroups().get(sample) || []).length > 1;
+      _grouped && sample && typeof specimenGroups === "function" && (specimenGroups().get(sample) || []).length > 1;
     const showAll = !sample || entries.length > 1 || selectedMergedSpecimen;
 
     if (!entries.length || entries.every((cd) => !cd.contigs || !cd.contigs.length)) {

--- a/assets/src/js/18_tab_summary.js
+++ b/assets/src/js/18_tab_summary.js
@@ -38,7 +38,8 @@ function _orgBadges(r) {
   if (mt === "dna") s += '<span title="DNA" style="color:#1565c0;font-weight:700">Ⓓ</span> ';
   else if (mt === "rna") s += '<span title="RNA" style="color:#6a1b9a;font-weight:700">Ⓡ</span> ';
   else if (mt === "both")
-    s += '<span title="Merged DNA + RNA evidence" style="color:#1565c0;font-weight:700">Ⓓ</span><span title="Merged DNA + RNA evidence" style="color:#6a1b9a;font-weight:700">Ⓡ</span> ';
+    s +=
+      '<span title="Merged DNA + RNA evidence" style="color:#1565c0;font-weight:700">Ⓓ</span><span title="Merged DNA + RNA evidence" style="color:#6a1b9a;font-weight:700">Ⓡ</span> ';
   return s;
 }
 
@@ -115,7 +116,9 @@ function _summaryMetaFor(sn, fd) {
     specimenMergeEnabled &&
     typeof specimenGroups === "function" &&
     specimenGroups().has(sn)
-      ? specimenGroups().get(sn).filter((s) => !sampleHidden[s])
+      ? specimenGroups()
+          .get(sn)
+          .filter((s) => !sampleHidden[s])
       : row && Array.isArray(row.__mergedFrom) && row.__mergedFrom.length
       ? row.__mergedFrom
       : [sn];
@@ -430,6 +433,42 @@ function drawSummary() {
 
   const aReads = _fmtBig(totalOrg);
   const allReads = _fmtBig(totalInputUnfiltered);
+  // Count unique taxa at the strain level (or the lowest level available).
+  // DATA stacks Strain/Species/Genus rollup rows for the same organism
+  // (sharing "Subkey"), and multiple distinct strains of one species share
+  // that same Species/Genus proxy row (see _synthesizeHierarchy in
+  // 23_filter_listeners.js) — so collapsing to one row per (Specimen, Subkey)
+  // undercounts whenever a species has >1 strain in a sample. Instead: count
+  // every Strain-level row's own taxid (never collapsed), and only fall back
+  // to a Species/Genus taxid for a (Specimen, Subkey) group that has no
+  // Strain-level row at all. This guarantees the total is never lower than
+  // any Strain-level "Organisms" count derived from a subset of DATA.
+  const _strainGroupKeys = new Set();
+  for (const r of DATA) {
+    if ((r["Level"] || "Strain") === "Strain") {
+      _strainGroupKeys.add((r["Specimen ID"] || "") + "||" + (r["Subkey"] || r["Taxonomic ID #"] || ""));
+    }
+  }
+  const _fallbackLevelRank = { Species: 2, Genus: 1 };
+  const _fallbackTaxidByGroup = new Map();
+  const _strainTaxids = new Set();
+  for (const r of DATA) {
+    const lvl = r["Level"] || "Strain";
+    if (lvl === "Strain") {
+      _strainTaxids.add(r["Taxonomic ID #"] || "");
+      continue;
+    }
+    const gk = (r["Specimen ID"] || "") + "||" + (r["Subkey"] || r["Taxonomic ID #"] || "");
+    if (_strainGroupKeys.has(gk)) continue; // covered by a Strain row already
+    const rank = _fallbackLevelRank[lvl] || 0;
+    const cur = _fallbackTaxidByGroup.get(gk);
+    if (!cur || rank > cur.rank) {
+      _fallbackTaxidByGroup.set(gk, { rank, taxid: r["Taxonomic ID #"] || "" });
+    }
+  }
+  const total_taxa_notfilter = new Set(
+    [..._strainTaxids, ...Array.from(_fallbackTaxidByGroup.values()).map((g) => g.taxid)].filter(Boolean),
+  ).size;
   const cards = [
     {
       label: "Samples",
@@ -451,7 +490,7 @@ function drawSummary() {
       subFull: aReads.full,
       tipId: "kpi-tip-pct",
     },
-    { label: "Organisms", value: _fmtInt(uniqOrgs), sub: "unique taxa" },
+    { label: "Organisms", value: _fmtInt(uniqOrgs), sub: `passing filter<br>Total: ${_fmtInt(total_taxa_notfilter)}` },
     { label: "Genera", value: _fmtInt(uniqGenera), sub: "unique genera" },
     { label: "High Consequence", value: _fmtInt(hcCount), sub: "flagged pathogens" },
     { label: "TASS Cutoff", value: cutVal, sub: cutSub, tipId: "kpi-tip-tass" },
@@ -1111,7 +1150,9 @@ function _renderSummaryTable(fd) {
         const _brd = _histRes.combined && _histRes.unionPct != null ? _histRes.unionPct : num(r["Breadth %"]);
         const _mk = _histRes.combined
           ? `<span title="${
-              _histRes.exact ? "Exact positional union of breadth across the merged samples" : "Combined (per-bin max) breadth across the merged samples"
+              _histRes.exact
+                ? "Exact positional union of breadth across the merged samples"
+                : "Combined (per-bin max) breadth across the merged samples"
             }" style="color:#1565c0;font-size:0.82em;margin-left:2px;">∪</span>`
           : "";
         return `<td style="text-align:right">${_brd.toFixed(1)}${_mk}</td>`;
@@ -1482,7 +1523,8 @@ function _noveltyCellHTML(r) {
 
   const lvl = speciesCand ? "sp" : "gen";
   const cand = speciesCand || genusCand;
-  const hrFrac = cand.frac_of_highrank != null && cand.frac_of_highrank !== "" ? parseFloat(cand.frac_of_highrank) : NaN;
+  const hrFrac =
+    cand.frac_of_highrank != null && cand.frac_of_highrank !== "" ? parseFloat(cand.frac_of_highrank) : NaN;
   const sampleFrac = cand.frac_of_sample != null && cand.frac_of_sample !== "" ? parseFloat(cand.frac_of_sample) : NaN;
   const fracPct = !isNaN(hrFrac)
     ? (hrFrac * 100).toFixed(1) + "% of genus+ pool"

--- a/assets/src/js/18_tab_summary.js
+++ b/assets/src/js/18_tab_summary.js
@@ -37,6 +37,8 @@ function _orgBadges(r) {
   const mt = String(r["Mol Type"] || "").toLowerCase();
   if (mt === "dna") s += '<span title="DNA" style="color:#1565c0;font-weight:700">Ⓓ</span> ';
   else if (mt === "rna") s += '<span title="RNA" style="color:#6a1b9a;font-weight:700">Ⓡ</span> ';
+  else if (mt === "both")
+    s += '<span title="Merged DNA + RNA evidence" style="color:#1565c0;font-weight:700">Ⓓ</span><span title="Merged DNA + RNA evidence" style="color:#6a1b9a;font-weight:700">Ⓡ</span> ';
   return s;
 }
 
@@ -66,6 +68,7 @@ function _rowKeywords(r) {
   if (_orgHasAmr(r)) chips.push({ t: "AMR", c: "kw-amr" });
   const mt = String(r["Mol Type"] || "").toLowerCase();
   if (mt === "dna" || mt === "rna") chips.push({ t: mt.toUpperCase(), c: "" });
+  else if (mt === "both") chips.push({ t: "DNA + RNA", c: "" });
   const genus = r["Genus"];
   if (genus) chips.push({ t: genus, c: "" });
   const fam = r["Family"];
@@ -95,10 +98,130 @@ function _invalidateSummaryHistMap() {
     _VFAMR_INDEX = null;
   } catch (e) {}
 }
+// Resolve SAMPLE_META for a Summary "sample" row. Ordinarily `sn` is a real
+// sample id and SAMPLE_META[sn] just works. When specimen merge is on, `sn`
+// is instead the merged specimen NAME (fd rows carry it in "Specimen ID"),
+// which SAMPLE_META has no entry for — every per-sample metric (total_reads,
+// total_organism_reads, platform) would silently read as 0/undefined,
+// producing the "N/A" / NaN% KPI cards. Resolve the row's __mergedFrom member
+// samples and sum/union their metadata instead.
+function _summaryMetaFor(sn, fd) {
+  const row = (fd || []).find((r) => r["Specimen ID"] === sn);
+  // A detection row's __mergedFrom contains only members contributing that
+  // organism. KPI denominators must instead include every visible library in
+  // the specimen, including members with no row for that organism.
+  let members =
+    typeof specimenMergeEnabled !== "undefined" &&
+    specimenMergeEnabled &&
+    typeof specimenGroups === "function" &&
+    specimenGroups().has(sn)
+      ? specimenGroups().get(sn).filter((s) => !sampleHidden[s])
+      : row && Array.isArray(row.__mergedFrom) && row.__mergedFrom.length
+      ? row.__mergedFrom
+      : [sn];
+  if (!members.length) members = [sn];
+  if (members.length <= 1) return SAMPLE_META[members[0]] || {};
+  let total_reads = 0,
+    total_organism_reads = 0;
+  const platforms = new Set();
+  members.forEach((m) => {
+    const mm = SAMPLE_META[m] || {};
+    total_reads += parseFloat(mm.total_reads) || 0;
+    total_organism_reads += parseFloat(mm.total_organism_reads) || 0;
+    if (mm.platform && mm.platform !== "unknown") platforms.add(mm.platform);
+  });
+  return { total_reads, total_organism_reads, platform: Array.from(platforms).join(" + ") };
+}
 const _DEPTH_BINS = ["0x", "1-5x", "5-10x", "10-50x", ">50x"];
 const _DEPTH_COLORS = ["#dee2e6", "#a5d8ff", "#74c0fc", "#4dabf7", "#1c7ed6"];
+// Resolve the CONTIG_DATA entry (and a real sample||org||taxon key) for a
+// summary row. A merged-specimen row carries the specimen NAME in "Specimen
+// ID", which is not a CONTIG_DATA sample, so the direct lookup misses. In that
+// case we fall back to the row's member samples (__mergedFrom) and pick the
+// entry with the widest breadth of coverage — that keeps CONTIG_DATA keyed by
+// the original sample while still lighting up the sparkline / hover / jump for
+// merged rows. Returns { cd, key }; key is always resolvable by the Histogram
+// tab (it points at a genuine member sample when merged).
+function _histResolve(r) {
+  const map = _histMap();
+  const org = r["Detected Organism"];
+  const tax = r["Taxonomic ID #"];
+  const direct = `${r["Specimen ID"]}||${org}||${tax}`;
+  if (map.has(direct)) return { cd: map.get(direct), key: direct };
+  const members = Array.isArray(r.__mergedFrom) ? r.__mergedFrom : [];
+  let best = null,
+    bestKey = direct,
+    bestScore = -Infinity;
+  members.forEach((s) => {
+    const k = `${s}||${org}||${tax}`;
+    const cd = map.get(k);
+    if (!cd) return;
+    const bh = cd.breadth_histogram;
+    const score =
+      bh && Array.isArray(bh.bins) && bh.bins.length ? bh.bins.reduce((a, v) => a + num(v), 0) / bh.bins.length : 0;
+    if (score > bestScore) {
+      bestScore = score;
+      best = cd;
+      bestKey = k;
+    }
+  });
+  return { cd: best, key: bestKey };
+}
+// Whole-genome breadth % from a breadth histogram. Prefers the exact
+// breadth_pct recorded on a combined-union entry; otherwise weights each bin's
+// % covered by its real length (the last bin may be short).
+function _breadthPctFromBins(bh) {
+  if (!bh) return null;
+  if (bh.breadth_pct != null) return num(bh.breadth_pct);
+  if (!Array.isArray(bh.bins) || !bh.bins.length) return null;
+  const binSz = bh.bin_size || 0,
+    totLen = bh.total_len || 0;
+  if (binSz && totLen) {
+    let cov = 0;
+    for (let b = 0; b < bh.bins.length; b++) {
+      const blo = b * binSz,
+        bhi = Math.min((b + 1) * binSz, totLen);
+      cov += (num(bh.bins[b]) / 100) * Math.max(0, bhi - blo);
+    }
+    return totLen > 0 ? (cov / totLen) * 100 : null;
+  }
+  return bh.bins.reduce((a, v) => a + num(v), 0) / bh.bins.length;
+}
+
+// Coverage resolution for a Summary row's sparkline + breadth column. For a
+// merged specimen with 2+ contributing member samples we build the COMBINED
+// coverage (exact positional union when the report carries covered_intervals,
+// else per-bin max) so the column reflects the specimen as a whole rather than
+// its single strongest library. Returns:
+//   { cd, jumpSample, unionPct, combined, exact }
+function _histResolveCombined(r) {
+  const base = _histResolve(r);
+  const jump = (base.key || "").split("||")[0];
+  const members = Array.isArray(r.__mergedFrom) ? r.__mergedFrom : null;
+  if (!members || members.length < 2 || typeof _covCombineCds !== "function") {
+    return { cd: base.cd, jumpSample: jump, unionPct: null, combined: false, exact: false };
+  }
+  const org = r["Detected Organism"],
+    tax = r["Taxonomic ID #"];
+  const map = _histMap();
+  const memberCds = members.map((s) => ({ sample: s, cd: map.get(`${s}||${org}||${tax}`) })).filter((x) => x.cd);
+  if (memberCds.length < 2) {
+    return { cd: base.cd, jumpSample: jump, unionPct: null, combined: false, exact: false };
+  }
+  const syn = _covCombineCds(memberCds);
+  if (!syn || !syn.breadth_histogram) {
+    return { cd: base.cd, jumpSample: jump, unionPct: null, combined: false, exact: false };
+  }
+  return {
+    cd: syn,
+    jumpSample: jump,
+    unionPct: _breadthPctFromBins(syn.breadth_histogram),
+    combined: true,
+    exact: !!syn.__exactUnion,
+  };
+}
 function _histFor(r) {
-  return _histMap().get(`${r["Specimen ID"]}||${r["Detected Organism"]}||${r["Taxonomic ID #"]}`);
+  return _histResolve(r).cd;
 }
 // Per-position coverage profile from a CONTIG_DATA entry's breadth histogram.
 // Returns an array of 0–100 % values (one per genomic bin), or null.
@@ -249,10 +372,22 @@ function drawSummary() {
   const samples = uniq(fd.map((r) => r["Specimen ID"] || "")).filter(Boolean);
 
   // ── KPI cards ──────────────────────────────────────────────────────
-  const totalInput = samples.reduce((s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_reads) || 0), 0);
-  const totalOrg =
-    samples.reduce((s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_organism_reads) || 0), 0) ||
-    fd.reduce((s, r) => s + num(r["# Reads Aligned"]), 0);
+  const totalInput = samples.reduce((s, sn) => s + (parseFloat(_summaryMetaFor(sn, fd).total_reads) || 0), 0);
+  // Whole-run input reads are deliberately independent of every report
+  // filter, sample visibility, and specimen grouping. SAMPLE_META has one
+  // entry per raw library, so summing it counts aligned + unaligned reads
+  // exactly once even when the displayed rows have been merged.
+  const totalInputUnfiltered = Object.keys(SAMPLE_META || {}).reduce(
+    (s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_reads) || 0),
+    0,
+  );
+  // Aligned reads must reflect what's actually shown in the (filtered / merged)
+  // table below — e.g. searching "severe acute*" should sum only the matching
+  // rows' "# Reads Aligned", and merging specimens should show the merged
+  // row's already-summed total. SAMPLE_META's total_organism_reads is a
+  // whole-sample, filter-blind figure and was overriding both of those cases,
+  // so it's no longer used here.
+  const totalOrg = fd.reduce((s, r) => s + num(r["# Reads Aligned"]), 0);
   let pctClass = totalInput > 0 ? ((totalOrg / totalInput) * 100).toFixed(1) + "%" : "N/A";
   if (pctClass === "0.0%" && totalOrg > 0) pctClass = "<0.1%";
 
@@ -261,7 +396,7 @@ function drawSummary() {
   const hcCount = new Set(
     fd.filter((r) => isTruthy(r["High Consequence"])).map((r) => r["Taxonomic ID #"] || r["Detected Organism"]),
   ).size;
-  const platforms = uniq(samples.map((sn) => (SAMPLE_META[sn] || {}).platform).filter((p) => p && p !== "unknown"));
+  const platforms = uniq(samples.map((sn) => _summaryMetaFor(sn, fd).platform).filter((p) => p && p !== "unknown"));
   // Applied TASS cutoffs — per sample type when available, otherwise global fallback.
   const _kpiTypes = Array.from(
     new Set(DATA.map((r) => (r["Sample Type"] || "").trim().toLowerCase()).filter((t) => t && t !== "unknown")),
@@ -293,8 +428,8 @@ function drawSummary() {
     cutSub = _recCut != null ? `recommended ${_recCut.toFixed(1)}` : "applied filter";
   }
 
-  const tReads = _fmtBig(totalInput);
   const aReads = _fmtBig(totalOrg);
+  const allReads = _fmtBig(totalInputUnfiltered);
   const cards = [
     {
       label: "Samples",
@@ -304,9 +439,9 @@ function drawSummary() {
     },
     {
       label: "Total Reads",
-      value: totalInput > 0 ? tReads.short : "N/A",
-      full: tReads.full,
-      sub: "input reads",
+      value: allReads.short,
+      full: allReads.full,
+      sub: "aligned + unaligned, without filters",
       tipId: "kpi-tip-reads",
     },
     {
@@ -333,6 +468,7 @@ function drawSummary() {
         `<div class="kpi-label">${c.label}${c.tipId || c.label === "High Consequence" ? infoIcon : ""}</div>` +
         `<div class="kpi-value"${c.full ? ` title="${c.full}"` : ""}>${c.value}</div>` +
         (c.sub ? `<div class="kpi-sub"${c.subFull ? ` title="${c.subFull}"` : ""}>${c.sub}</div>` : "") +
+        (c.sub2 ? `<div class="kpi-sub"${c.sub2Full ? ` title="${c.sub2Full}"` : ""}>${c.sub2}</div>` : "") +
         `</div>`,
     )
     .join("");
@@ -388,7 +524,7 @@ function drawSummary() {
   if (sampCard) {
     const sampRows = samples
       .map((sn) => {
-        const m = SAMPLE_META[sn] || {};
+        const m = _summaryMetaFor(sn, fd);
         const reads = m.total_reads ? _fmtBig(m.total_reads).short : "—";
         const plat = m.platform && m.platform !== "unknown" ? m.platform : "";
         return (
@@ -411,11 +547,11 @@ function drawSummary() {
 
   // ── KPI tooltips: Total Reads ──────────────────────────────────────
   const readsCard = document.getElementById("kpi-tip-reads");
-  if (readsCard && totalInput > 0) {
+  if (readsCard) {
     const rRows = samples
       .map((sn) => {
-        const r = parseFloat((SAMPLE_META[sn] || {}).total_reads) || 0;
-        const pct = totalInput > 0 ? ((r / totalInput) * 100).toFixed(1) + "%" : "—";
+        const r = fd.filter((row) => row["Specimen ID"] === sn).reduce((s, row) => s + num(row["# Reads Aligned"]), 0);
+        const pct = totalOrg > 0 ? ((r / totalOrg) * 100).toFixed(1) + "%" : "—";
         return (
           `<tr><td style="padding:2px 8px 2px 0;white-space:nowrap;color:#e0e0e0">${sn}</td>` +
           `<td style="padding:2px 4px;text-align:right;color:#90caf9">${_fmtBig(r).short}</td>` +
@@ -424,10 +560,11 @@ function drawSummary() {
       })
       .join("");
     const readsTip =
-      `<b style="color:#90caf9">Total input reads</b><br>` +
-      `<span style="color:#aaa;font-size:0.85em">Full count: ${tReads.full}</span><br>` +
+      `<b style="color:#90caf9">Reads aligned in the filtered view</b><br>` +
+      `<span style="color:#aaa;font-size:0.85em">Sum of the Reads column for the rows currently shown: ${aReads.full}</span><br>` +
+      `<span style="color:#aaa;font-size:0.85em">Whole-run input reads (aligned + unaligned, no filters): ${allReads.full}</span><br>` +
       `<table style="margin-top:5px;border-collapse:collapse">` +
-      `<tr style="color:#888;font-size:0.78em"><td style="padding-right:8px">Sample</td><td style="padding-right:4px;text-align:right">Reads</td><td style="text-align:right">Share</td></tr>` +
+      `<tr style="color:#888;font-size:0.78em"><td style="padding-right:8px">Sample</td><td style="padding-right:4px;text-align:right">Aligned</td><td style="text-align:right">Share</td></tr>` +
       rRows +
       `</table>`;
     readsCard.addEventListener("mouseover", (ev) => showTip(readsTip, ev));
@@ -440,9 +577,11 @@ function drawSummary() {
   if (pctCard) {
     const pctRows = samples
       .map((sn) => {
-        const m = SAMPLE_META[sn] || {};
-        const inp = parseFloat(m.total_reads) || 0;
-        const aln = parseFloat(m.total_organism_reads) || 0;
+        const inp = parseFloat(_summaryMetaFor(sn, fd).total_reads) || 0;
+        // Aligned reads for just this sample's rows in the currently
+        // filtered/merged table — mirrors the headline totalOrg above,
+        // rather than the sample's whole-run (filter-blind) total.
+        const aln = fd.filter((r) => r["Specimen ID"] === sn).reduce((s, r) => s + num(r["# Reads Aligned"]), 0);
         const p = inp > 0 ? ((aln / inp) * 100).toFixed(1) + "%" : "—";
         return (
           `<tr><td style="padding:2px 8px 2px 0;white-space:nowrap;color:#e0e0e0">${sn}</td>` +
@@ -872,7 +1011,8 @@ function _renderSummaryTable(fd) {
     if (grouped && r["Specimen ID"] !== lastSample) {
       lastSample = r["Specimen ID"];
       const _grpSwatchColor = sampleColors[lastSample] || "#90a4ae";
-      html += `<tr class="grp-row"><td colspan="${_visSumCols.length}"> <span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:${_grpSwatchColor};vertical-align:middle;margin:0 5px 1px 0;border:1px solid rgba(0,0,0,0.18);flex-shrink:0"></span>${lastSample}</td></tr>`;
+      const _mergedBadge = typeof _mergedSampleBadgeHTML === "function" ? _mergedSampleBadgeHTML(r) : "";
+      html += `<tr class="grp-row"><td colspan="${_visSumCols.length}"> <span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:${_grpSwatchColor};vertical-align:middle;margin:0 5px 1px 0;border:1px solid rgba(0,0,0,0.18);flex-shrink:0"></span>${lastSample}${_mergedBadge}</td></tr>`;
     }
     // VF/AMR-only indicator row (sample has no passing detections).
     if (r.__vfamrOnly) {
@@ -899,7 +1039,8 @@ function _renderSummaryTable(fd) {
     const cc = _CAT_COLORS[cat] || "#555";
     const hc = isTruthy(r["High Consequence"]);
     const key = _sumRowKey(r);
-    const hist = _histFor(r);
+    const _histRes = _histResolveCombined(r);
+    const hist = _histRes.cd;
     const _pi_s = rowPassInfo(r);
     const _rescued_s = _pi_s && _pi_s.rescued;
     const _rescueBadge = _rescued_s
@@ -951,7 +1092,9 @@ function _renderSummaryTable(fd) {
               : '<span style="color:#ccc">—</span>'
           }</td>`
         : "") +
-      `<td>${r["Specimen ID"] || ""}</td>` +
+      `<td>${r["Specimen ID"] || ""}${
+        typeof _mergedSampleBadgeHTML === "function" ? _mergedSampleBadgeHTML(r) : ""
+      }</td>` +
       `<td><span style="color:${cc};font-weight:600">${cat}</span></td>` +
       `<td style="text-align:right">${num(r["TASS Score"]).toFixed(1)}</td>` +
       `<td style="text-align:center">${_summaryRescueCellHTML(r, key)}</td>` +
@@ -961,7 +1104,18 @@ function _renderSummaryTable(fd) {
       `<td style="text-align:right" title="${_fmtInt(r["# Reads Aligned"])}">${
         _fmtBig(r["# Reads Aligned"]).short
       }</td>` +
-      `<td style="text-align:right">${num(r["Breadth %"]).toFixed(1)}</td>` +
+      (function () {
+        // For a merged specimen, show the COMBINED breadth (exact positional
+        // union when available) instead of the strongest single library's
+        // value, with a small ∪ marker + tooltip so it's unambiguous.
+        const _brd = _histRes.combined && _histRes.unionPct != null ? _histRes.unionPct : num(r["Breadth %"]);
+        const _mk = _histRes.combined
+          ? `<span title="${
+              _histRes.exact ? "Exact positional union of breadth across the merged samples" : "Combined (per-bin max) breadth across the merged samples"
+            }" style="color:#1565c0;font-size:0.82em;margin-left:2px;">∪</span>`
+          : "";
+        return `<td style="text-align:right">${_brd.toFixed(1)}${_mk}</td>`;
+      })() +
       `<td>${
         r["Sample Type"] && r["Sample Type"] !== "unknown" ? r["Sample Type"] : '<span style="color:#ccc">—</span>'
       }</td>` +
@@ -1019,28 +1173,32 @@ function _renderSummaryTable(fd) {
       _updateSumPinBar();
     });
   });
-  // Wire spark hover preview + click-to-open in Histogram tab
+  // Build a key→row lookup from the current page slice so we can resolve data
+  // on hover (shared by the spark wiring and the strain-breakdown tooltip).
+  const _sumSliceMap = new Map();
+  slice.forEach(function (r) {
+    _sumSliceMap.set(_sumRowKey(r), r);
+  });
+  // Wire spark hover preview + click-to-open in Histogram tab. data-spark is the
+  // row key, so we resolve back to the actual row and reuse _histResolveCombined
+  // — the hover/preview then reflects the SAME combined-union coverage shown in
+  // the cell (not a single member library).
   wrap.querySelectorAll("[data-spark]").forEach((sp) => {
     const key = sp.dataset.spark;
-    const cd = _histMap().get(key);
+    const row = _sumSliceMap.get(key);
+    if (!row) return;
+    const res = _histResolveCombined(row);
+    const cd = res.cd;
     if (!cd) return;
-    const parts = key.split("||");
-    const r = { "Detected Organism": parts[1], "Specimen ID": parts[0], "Taxonomic ID #": parts[2] };
     sp.style.cursor = "pointer";
-    sp.addEventListener("mouseover", (ev) => showTip(_histPreviewHtml(r, cd), ev));
+    sp.addEventListener("mouseover", (ev) => showTip(_histPreviewHtml(row, cd), ev));
     sp.addEventListener("mousemove", moveTip);
     sp.addEventListener("mouseout", hideTip);
     sp.addEventListener("click", (e) => {
       e.stopPropagation();
       hideTip();
-      _jumpToHistogram(parts[1], parts[2], parts[0]);
+      _jumpToHistogram(row["Detected Organism"], row["Taxonomic ID #"], res.jumpSample);
     });
-  });
-  // Strain-breakdown hover tooltip for Species / Genus rows in the summary table.
-  // Build a key→row lookup from the current page slice so we can resolve data on hover.
-  const _sumSliceMap = new Map();
-  slice.forEach(function (r) {
-    _sumSliceMap.set(_sumRowKey(r), r);
   });
   wrap.querySelectorAll("tbody tr[data-key]").forEach(function (tr) {
     // skip group-header rows (they have no data-key — already filtered by selector)
@@ -1324,12 +1482,13 @@ function _noveltyCellHTML(r) {
 
   const lvl = speciesCand ? "sp" : "gen";
   const cand = speciesCand || genusCand;
-  const fracPct =
-    cand.frac_of_highrank != null
-      ? (parseFloat(cand.frac_of_highrank) * 100).toFixed(1) + "% of genus+ pool"
-      : cand.frac_of_sample != null
-      ? (parseFloat(cand.frac_of_sample) * 100).toFixed(3) + "% of sample"
-      : "";
+  const hrFrac = cand.frac_of_highrank != null && cand.frac_of_highrank !== "" ? parseFloat(cand.frac_of_highrank) : NaN;
+  const sampleFrac = cand.frac_of_sample != null && cand.frac_of_sample !== "" ? parseFloat(cand.frac_of_sample) : NaN;
+  const fracPct = !isNaN(hrFrac)
+    ? (hrFrac * 100).toFixed(1) + "% of genus+ pool"
+    : !isNaN(sampleFrac)
+    ? (sampleFrac * 100).toFixed(3) + "% of sample"
+    : "";
   const reads = cand.reads ? parseInt(cand.reads).toLocaleString() + ` ${_novUnit()}` : "";
   const tipParts = [
     `<b style="color:#f76707">Novelty signal — ${lvl === "sp" ? "species" : "genus"} level</b>`,
@@ -1487,6 +1646,9 @@ function _vfamrOnlySampleRows(fdRows) {
   ids.forEach((smp) => {
     if (sampleHidden[smp]) return;
     if (present.has(smp)) return;
+    // Merged-away member samples are represented by their specimen — don't
+    // render a stray "no detections" indicator for them.
+    if (typeof _isMergedAway === "function" && _isMergedAway(smp)) return;
     // When the user is text-searching organisms, don't surface sample-level
     // indicators (would be noise); for sample/both scope require a name match.
     if (rx && scope === "organism") return;
@@ -1641,6 +1803,7 @@ function _noveltyOnlySampleRows(fdRows) {
   ids.forEach((smp) => {
     if (sampleHidden[smp]) return;
     if (present.has(smp)) return;
+    if (typeof _isMergedAway === "function" && _isMergedAway(smp)) return;
     if (rx && scope === "organism") return;
     if (rx && scope !== "organism" && !rx.test(smp)) return;
     out.push({ "Specimen ID": smp, "Detected Organism": "", __noveltyOnly: true, __novelty: summary[smp] });
@@ -1747,6 +1910,7 @@ function _emptyOnlySampleRows(fdRows) {
   allSamples.forEach((smp) => {
     if (sampleHidden[smp]) return;
     if (present.has(smp)) return;
+    if (typeof _isMergedAway === "function" && _isMergedAway(smp)) return;
     if (rx && scope === "organism") return;
     if (rx && scope !== "organism" && !rx.test(smp)) return;
     out.push({

--- a/assets/src/js/18_tab_summary.js
+++ b/assets/src/js/18_tab_summary.js
@@ -1008,7 +1008,7 @@ function _renderSummaryTable(fd) {
     const d = String(a[col] || "").localeCompare(String(b[col] || ""));
     return _sumSortAsc ? d : -d;
   };
-  const _sumGrpIdx = _sampleOrder.length ? Object.fromEntries(_sampleOrder.map((id, i) => [id, i])) : {};
+  const _sumGrpIdx = _sampleOrGroupIndexMap();
   rows.sort((a, b) => {
     // When grouping, order groups by _sampleOrder (right-panel order), then sort within.
     if (grouped) {

--- a/assets/src/js/19_cross_sample_organism.js
+++ b/assets/src/js/19_cross_sample_organism.js
@@ -72,14 +72,21 @@ function _aniMatchesFor(r) {
 // Per sample we keep the MAX TASS / coverage so a single organism that
 // appears at several taxonomic levels in one sample counts once.
 function _xsAggregate(fd) {
-  const totalSamples = uniq(fd.map((r) => r["Specimen ID"] || "").filter(Boolean));
-  const N = totalSamples.length || 1;
+  // Distinct specimens present in the current (filtered) view — numerators
+  // reference these. When specimen merge is on, DNA/RNA libraries of the same
+  // specimen collapse to a single key here.
+  const viewSpecimens = uniq(fd.map((r) => specimenKey(r["Specimen ID"])).filter(Boolean));
+  // Prevalence denominator: specimens with ANY positive hit across the whole
+  // run (Passes Threshold), independent of the live TASS slider. Falls back to
+  // the in-view specimen count when the report carries no Passes-Threshold
+  // flags (older data), so prevalence never divides by zero.
+  const N = positiveHitSpecimenCount() || viewSpecimens.length || 1;
   const byOrg = new Map();
-  // Per-sample ANI capability: which samples carry ANI annotation at all.
+  // Per-specimen ANI capability: which specimens carry ANI annotation at all.
   const aniSamples = new Set();
   const noAniSamples = new Set();
   fd.forEach((r) => {
-    const sn = r["Specimen ID"] || "";
+    const sn = specimenKey(r["Specimen ID"]);
     if (!sn) return;
     (_aniAnnotated(r) ? aniSamples : noAniSamples).add(sn);
     const taxid = (r["Taxonomic ID #"] || "").toString();
@@ -122,7 +129,7 @@ function _xsAggregate(fd) {
       cat: e.cat,
       hc: e.hc,
       sampleCount: e.tassMap.size,
-      samplePct: (e.tassMap.size / N) * 100,
+      samplePct: Math.min(100, (e.tassMap.size / N) * 100),
       meanTass: _xsMean(tass),
       medianTass: _xsMed(tass),
       maxTass: tass.length ? Math.max(...tass) : 0,
@@ -176,7 +183,7 @@ function _xsAggregate(fd) {
   return {
     rows,
     totalSamples: N,
-    sampleList: totalSamples,
+    sampleList: viewSpecimens,
     aniSamples,
     noAniSamples,
     aniGroups: _groupMembers,
@@ -195,6 +202,145 @@ function _xsCatColor(cat) {
   return _CAT_COLORS[(cat || "Unknown").split(";")[0]] || "#607d8b";
 }
 
+// ── Specimen merge: toggle + membership editor ───────────────────────────
+// Sync the toggle button label/style and the "sample(s)"/"specimen(s)" unit
+// wording to the current merge state. Hides the controls when the run has no
+// specimen grouping to act on (nothing would change).
+function _xsUpdateSpecimenControls() {
+  const has = typeof hasSpecimenGrouping === "function" ? hasSpecimenGrouping() : false;
+  const tog = document.getElementById("xs-specimen-toggle");
+  const edit = document.getElementById("xs-specimen-edit");
+  const lbl = document.getElementById("xs-specimen-lbl");
+  // The editor is always useful (you can create grouping live); the toggle is
+  // only meaningful once at least one multi-sample specimen exists.
+  if (tog) {
+    tog.style.display = has ? "" : "none";
+    tog.textContent = "Merge: " + (specimenMergeEnabled ? "On" : "Off");
+    tog.style.background = specimenMergeEnabled ? "#1565c0" : "#fff";
+    tog.style.color = specimenMergeEnabled ? "#fff" : "#1565c0";
+  }
+  if (lbl) lbl.style.display = "";
+  if (edit) edit.style.display = "";
+  // Swap the unit noun in the summary note.
+  const unit = document.getElementById("xs-unit");
+  if (unit) unit.textContent = specimenMergeEnabled ? "specimen(s)" : "sample(s)";
+}
+
+function _xsToggleSpecimenMerge() {
+  const next = !specimenMergeEnabled;
+  if (window.specimenMerge && typeof window.specimenMerge.setEnabled === "function") {
+    window.specimenMerge.setEnabled(next);
+    return;
+  }
+  specimenMergeEnabled = next;
+  if (typeof _invalidateFilterCache === "function") _invalidateFilterCache();
+  if (typeof _rebuildMapMarkers === "function") _rebuildMapMarkers();
+  const fd = typeof filteredData === "function" ? filteredData() : [];
+  _drawCrossSample(fd, null);
+}
+
+// Build (once) and open a modal that lists every sample and the specimen it is
+// assigned to. Editing a specimen name and applying re-groups the samples live
+// via SPECIMEN_OVERRIDE, then re-renders with merge enabled.
+function _xsOpenSpecimenEditor() {
+  let back = document.getElementById("xs-specimen-modal");
+  if (back) back.remove();
+  back = document.createElement("div");
+  back.id = "xs-specimen-modal";
+  back.style.cssText =
+    "position:fixed;inset:0;background:rgba(0,0,0,0.45);z-index:10000;display:flex;align-items:center;justify-content:center;";
+
+  const groups = specimenGroups();
+  // Flatten to [sample, currentSpecimen] rows, grouped for readability.
+  const rowsHtml = [];
+  groups.forEach((members, g) => {
+    members.forEach((s) => {
+      const safeS = String(s).replace(/"/g, "&quot;");
+      const safeG = String(g).replace(/"/g, "&quot;");
+      const isGrouped = members.length > 1;
+      rowsHtml.push(
+        `<tr>` +
+          `<td style="padding:4px 8px;font-size:0.85em;white-space:nowrap;">${safeS}</td>` +
+          `<td style="padding:4px 8px;">` +
+          `<input class="xs-sp-input" data-sample="${safeS}" value="${safeG}" ` +
+          `style="width:100%;box-sizing:border-box;padding:3px 6px;border:1px solid ${
+            isGrouped ? "#1565c0" : "#ccc"
+          };border-radius:4px;font-size:0.85em;" />` +
+          `</td></tr>`,
+      );
+    });
+  });
+
+  back.innerHTML =
+    `<div style="background:#fff;border-radius:8px;max-width:560px;width:92%;max-height:80vh;display:flex;flex-direction:column;box-shadow:0 8px 30px rgba(0,0,0,0.3);">` +
+    `<div style="padding:14px 18px;border-bottom:1px solid #eee;display:flex;align-items:center;gap:8px;">` +
+    `<b style="font-size:1.02em;color:#1565c0;">Edit specimens</b>` +
+    `<span style="flex:1"></span>` +
+    `<span style="cursor:pointer;font-size:1.3em;color:#888;" id="xs-sp-close">&times;</span>` +
+    `</div>` +
+    `<div style="padding:6px 18px;font-size:0.82em;color:#666;">Give samples the same <b>specimen</b> value to merge them (e.g. a DNA and RNA library from one swab). Prevalence and per-organism TASS / coverage / reads then aggregate per specimen.</div>` +
+    `<div style="overflow:auto;padding:4px 18px 10px;">` +
+    `<table style="width:100%;border-collapse:collapse;">` +
+    `<thead><tr>` +
+    `<th style="text-align:left;padding:4px 8px;font-size:0.78em;color:#888;border-bottom:1px solid #eee;">Sample</th>` +
+    `<th style="text-align:left;padding:4px 8px;font-size:0.78em;color:#888;border-bottom:1px solid #eee;">Specimen</th>` +
+    `</tr></thead><tbody>${rowsHtml.join("")}</tbody></table>` +
+    `</div>` +
+    `<div style="padding:12px 18px;border-top:1px solid #eee;display:flex;gap:8px;justify-content:flex-end;">` +
+    `<button id="xs-sp-reset" style="padding:5px 12px;border:1px solid #ccc;border-radius:5px;background:#fff;color:#666;cursor:pointer;font-size:0.85em;">Reset to samplesheet</button>` +
+    `<span style="flex:1"></span>` +
+    `<button id="xs-sp-cancel" style="padding:5px 12px;border:1px solid #ccc;border-radius:5px;background:#fff;color:#666;cursor:pointer;font-size:0.85em;">Cancel</button>` +
+    `<button id="xs-sp-apply" style="padding:5px 14px;border:1px solid #1565c0;border-radius:5px;background:#1565c0;color:#fff;cursor:pointer;font-size:0.85em;font-weight:600;">Apply</button>` +
+    `</div></div>`;
+
+  document.body.appendChild(back);
+
+  const close = () => back.remove();
+  back.addEventListener("click", (e) => {
+    if (e.target === back) close();
+  });
+  document.getElementById("xs-sp-close").addEventListener("click", close);
+  document.getElementById("xs-sp-cancel").addEventListener("click", close);
+
+  document.getElementById("xs-sp-reset").addEventListener("click", () => {
+    Object.keys(SPECIMEN_OVERRIDE).forEach((k) => delete SPECIMEN_OVERRIDE[k]);
+    close();
+    if (window.specimenMerge && typeof window.specimenMerge.setEnabled === "function") {
+      window.specimenMerge.setEnabled(specimenMergeEnabled);
+      return;
+    }
+    if (typeof _invalidateFilterCache === "function") _invalidateFilterCache();
+    if (typeof _rebuildMapMarkers === "function") _rebuildMapMarkers();
+    const fd = typeof filteredData === "function" ? filteredData() : [];
+    _drawCrossSample(fd, null);
+  });
+
+  document.getElementById("xs-sp-apply").addEventListener("click", () => {
+    back.querySelectorAll(".xs-sp-input").forEach((inp) => {
+      const sample = inp.getAttribute("data-sample");
+      const val = (inp.value || "").trim();
+      // Determine the metadata default so we only keep genuine overrides.
+      const meta = (typeof SAMPLE_META !== "undefined" && SAMPLE_META[sample]) || {};
+      const metaSp =
+        meta.specimen != null ? meta.specimen : meta.specimen_id != null ? meta.specimen_id : meta.specimen_group;
+      const dflt = metaSp != null && String(metaSp).trim() ? String(metaSp).trim() : sample;
+      if (!val || val === dflt) delete SPECIMEN_OVERRIDE[sample];
+      else SPECIMEN_OVERRIDE[sample] = val;
+    });
+    // Turn merge on so the user immediately sees the effect of their grouping.
+    close();
+    if (window.specimenMerge && typeof window.specimenMerge.setEnabled === "function") {
+      window.specimenMerge.setEnabled(true);
+      return;
+    }
+    specimenMergeEnabled = true;
+    if (typeof _invalidateFilterCache === "function") _invalidateFilterCache();
+    if (typeof _rebuildMapMarkers === "function") _rebuildMapMarkers();
+    const fd = typeof filteredData === "function" ? filteredData() : [];
+    _drawCrossSample(fd, null);
+  });
+}
+
 function _drawCrossSample(fd, samples) {
   const wrap = document.getElementById("xs-wrap");
   if (!wrap) return;
@@ -202,6 +348,9 @@ function _drawCrossSample(fd, samples) {
   _XS.lastAgg = agg;
   const nsamp = document.getElementById("xs-nsamp");
   if (nsamp) nsamp.textContent = agg.totalSamples;
+  // Reflect the current specimen-merge state in the toggle + swap the unit
+  // wording between "sample(s)" and "specimen(s)".
+  _xsUpdateSpecimenControls();
 
   // populate category dropdown once per render (preserve selection)
   const catSel = document.getElementById("xs-cat");
@@ -228,6 +377,11 @@ function _drawCrossSample(fd, samples) {
     });
     const exp = document.getElementById("xs-export");
     if (exp) exp.addEventListener("click", _xsExportCsv);
+    // Specimen-merge toggle + membership editor.
+    const spTog = document.getElementById("xs-specimen-toggle");
+    if (spTog) spTog.addEventListener("click", _xsToggleSpecimenMerge);
+    const spEdit = document.getElementById("xs-specimen-edit");
+    if (spEdit) spEdit.addEventListener("click", _xsOpenSpecimenEditor);
     // sort handler (delegated) for the frequency table
     const body = document.getElementById("xs-body");
     if (body)

--- a/assets/src/js/21_compare_coverages.js
+++ b/assets/src/js/21_compare_coverages.js
@@ -284,7 +284,11 @@ function _covCombineCds(cds) {
         JSON.stringify(bh.contig_names || []) === JSON.stringify(ref.contig_names || []),
     );
     if (sameSpace && ref.total_len && ref.bin_size) {
-      const u = _covUnionRebin(bhs.map((bh) => bh.covered_intervals), ref.bin_size, ref.total_len);
+      const u = _covUnionRebin(
+        bhs.map((bh) => bh.covered_intervals),
+        ref.bin_size,
+        ref.total_len,
+      );
       if (u) {
         const breadth = {
           bins: u.bins,
@@ -304,7 +308,11 @@ function _covCombineCds(cds) {
 
   // ── Fallback: per-bin MAX (lower bound) ────────────────────────────────
   const binsArr = cds
-    .map(({ cd }) => (cd && cd.breadth_histogram && Array.isArray(cd.breadth_histogram.bins) ? cd.breadth_histogram.bins.map(num) : null))
+    .map(({ cd }) =>
+      cd && cd.breadth_histogram && Array.isArray(cd.breadth_histogram.bins)
+        ? cd.breadth_histogram.bins.map(num)
+        : null,
+    )
     .filter(Boolean);
   let breadth = null;
   let combinable = false;
@@ -321,8 +329,15 @@ function _covCombineCds(cds) {
         bins[i] = mx;
       }
       const refBh =
-        (cds.find(({ cd }) => cd && cd.breadth_histogram && Array.isArray(cd.breadth_histogram.bins) && cd.breadth_histogram.bins.length === L) || {}).cd
-          ?.breadth_histogram || {};
+        (
+          cds.find(
+            ({ cd }) =>
+              cd &&
+              cd.breadth_histogram &&
+              Array.isArray(cd.breadth_histogram.bins) &&
+              cd.breadth_histogram.bins.length === L,
+          ) || {}
+        ).cd?.breadth_histogram || {};
       breadth = { bins };
       if (refBh.bin_size != null) breadth.bin_size = refBh.bin_size;
       if (refBh.total_len != null) breadth.total_len = refBh.total_len;
@@ -360,9 +375,7 @@ function _covExpandMerged(raw) {
       out.push(Object.assign({}, it, { __mergedCd: combined, __mergedMembers: cds.map((c) => c.sample) }));
     } else {
       // Overlay: one line per member sample (keeps the specimen name as a hint).
-      cds.forEach(({ sample }) =>
-        out.push({ sample, organism: it.organism, taxid: it.taxid, __overlayOf: it.sample }),
-      );
+      cds.forEach(({ sample }) => out.push({ sample, organism: it.organism, taxid: it.taxid, __overlayOf: it.sample }));
     }
   });
   return out;
@@ -1904,9 +1917,7 @@ function _novSamples() {
     const total = summaries.reduce((a, sm) => a + (+sm.total_reads || 0), 0);
     const sum = (key) => summaries.reduce((a, sm) => a + (+sm[key] || 0), 0);
     const weighted = (key) =>
-      total
-        ? summaries.reduce((a, sm) => a + (+sm[key] || 0) * (+sm.total_reads || 0), 0) / total
-        : 0;
+      total ? summaries.reduce((a, sm) => a + (+sm[key] || 0) * (+sm.total_reads || 0), 0) / total : 0;
     const summary = Object.assign({}, summaries[0] || {}, {
       sample: group,
       total_reads: total,
@@ -2413,7 +2424,9 @@ function _novClosedGenus(sample) {
     typeof specimenGroups === "function" &&
     specimenGroups().has(sample)
   ) {
-    memberList = specimenGroups().get(sample).filter((s) => !(typeof sampleHidden !== "undefined" && sampleHidden[s]));
+    memberList = specimenGroups()
+      .get(sample)
+      .filter((s) => !(typeof sampleHidden !== "undefined" && sampleHidden[s]));
   }
   const members = new Set(memberList);
   (DATA || []).forEach((r) => {

--- a/assets/src/js/21_compare_coverages.js
+++ b/assets/src/js/21_compare_coverages.js
@@ -173,10 +173,206 @@ function _covAggArr(arrays, stat) {
   }
   return out;
 }
+/* ── Specimen-aware coverage merging ──────────────────────────────────────
+        When the merge toggle is on and an item's "sample" is really a merged
+        specimen, we cannot look its per-position coverage up directly (the
+        encoded CONTIG_DATA is keyed by the raw member samples). So we gather
+        the member samples' coverage and either:
+          • COMBINE it into one curve — when every member carries a per-position
+            profile of the SAME length (same reference), we take the per-position
+            union (max % covered) and pool the depth histograms; or
+          • OVERLAY it — when the profiles differ in length (different references
+            / contig sets) we can't combine honestly, so we fall back to drawing
+            one line per member sample.                                          */
+function _covSpecimenMembers(spec) {
+  if (typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled && typeof specimenGroups === "function") {
+    const g = specimenGroups().get(spec);
+    if (g && g.length) return g.slice();
+  }
+  return [spec];
+}
+function _covMemberCds(spec, organism, taxid) {
+  return _covSpecimenMembers(spec)
+    .map((m) => ({ sample: m, cd: _covFetch(m, organism, taxid) }))
+    .filter((x) => x.cd);
+}
+// OR a set of flat [s,e,s,e,…] covered-run lists into one merged run list, then
+// re-bin into per-bin % covered — mirrors the pipeline's _build_positional_bins
+// so the combined profile is computed the same way a single sample would be.
+// Returns { bins, unionBp } or null.
+function _covUnionRebin(flatList, binSize, totalLen) {
+  const all = [];
+  flatList.forEach((flat) => {
+    for (let i = 0; i + 1 < flat.length; i += 2) {
+      const s = num(flat[i]),
+        e = num(flat[i + 1]);
+      if (e > s) all.push([s, e]);
+    }
+  });
+  if (!all.length || !binSize || !totalLen) return null;
+  all.sort((a, b) => a[0] - b[0]);
+  const merged = [];
+  let cs = all[0][0],
+    ce = all[0][1];
+  for (let i = 1; i < all.length; i++) {
+    const s = all[i][0],
+      e = all[i][1];
+    if (s <= ce) {
+      if (e > ce) ce = e;
+    } else {
+      merged.push([cs, ce]);
+      cs = s;
+      ce = e;
+    }
+  }
+  merged.push([cs, ce]);
+  const n = Math.ceil(totalLen / binSize);
+  const coveredBp = new Array(n).fill(0);
+  merged.forEach(([s, e]) => {
+    const bi0 = Math.floor(s / binSize);
+    const bi1 = Math.min(n - 1, Math.floor(Math.max(s, e - 1) / binSize));
+    for (let b = bi0; b <= bi1; b++) {
+      const blo = b * binSize,
+        bhi = Math.min((b + 1) * binSize, totalLen);
+      coveredBp[b] += Math.max(0, Math.min(e, bhi) - Math.max(s, blo));
+    }
+  });
+  const bins = new Array(n);
+  for (let b = 0; b < n; b++) {
+    const blo = b * binSize,
+      bhi = Math.min((b + 1) * binSize, totalLen);
+    const blen = bhi - blo;
+    bins[b] = blen > 0 ? Math.round(Math.min(100, (coveredBp[b] / blen) * 100) * 10) / 10 : 0;
+  }
+  const unionBp = merged.reduce((a, iv) => a + (iv[1] - iv[0]), 0);
+  return { bins, unionBp };
+}
+
+// Build a synthetic combined CONTIG_DATA entry from member cds.
+//   • EXACT union — when every member carries covered_intervals in the SAME
+//     concatenated coordinate space (same total_len / bin_size / breaks /
+//     contig_names), we OR the runs and re-bin. Coverage present in one sample
+//     but not another is counted, so the union can exceed any single sample.
+//   • Per-bin MAX — fallback for older reports without covered_intervals; a
+//     conservative lower bound (never exceeds the strongest single sample).
+//   • Not combinable — different-length profiles (different references) can
+//     only be overlaid, so __combinable stays false.
+function _covCombineCds(cds) {
+  const depth = {};
+  cds.forEach(({ cd }) => {
+    const h = (cd && cd.depth_histogram) || {};
+    Object.keys(h).forEach((k) => (depth[k] = (depth[k] || 0) + num(h[k])));
+  });
+
+  const _base = {
+    __synthetic: true,
+    organism: cds[0].cd.organism,
+    taxon_id: cds[0].cd.taxon_id,
+    depth_histogram: depth,
+  };
+
+  // ── Exact union via covered_intervals ──────────────────────────────────
+  const bhs = cds.map(({ cd }) => (cd && cd.breadth_histogram) || null);
+  const haveIv = bhs.every((bh) => bh && Array.isArray(bh.covered_intervals) && bh.covered_intervals.length);
+  if (haveIv) {
+    const ref = bhs[0];
+    const sameSpace = bhs.every(
+      (bh) =>
+        bh.total_len === ref.total_len &&
+        bh.bin_size === ref.bin_size &&
+        JSON.stringify(bh.breaks || []) === JSON.stringify(ref.breaks || []) &&
+        JSON.stringify(bh.contig_names || []) === JSON.stringify(ref.contig_names || []),
+    );
+    if (sameSpace && ref.total_len && ref.bin_size) {
+      const u = _covUnionRebin(bhs.map((bh) => bh.covered_intervals), ref.bin_size, ref.total_len);
+      if (u) {
+        const breadth = {
+          bins: u.bins,
+          bin_size: ref.bin_size,
+          total_len: ref.total_len,
+          // Exact union breadth = union-covered bp ÷ genome length. Recorded so
+          // the Summary column can show the real number, not a per-bin average.
+          breadth_pct: ref.total_len ? Math.round((u.unionBp / ref.total_len) * 1000) / 10 : null,
+          __exactUnion: true,
+        };
+        if (Array.isArray(ref.breaks)) breadth.breaks = ref.breaks;
+        if (Array.isArray(ref.contig_names)) breadth.contig_names = ref.contig_names;
+        return Object.assign(_base, { __combinable: true, __exactUnion: true, breadth_histogram: breadth });
+      }
+    }
+  }
+
+  // ── Fallback: per-bin MAX (lower bound) ────────────────────────────────
+  const binsArr = cds
+    .map(({ cd }) => (cd && cd.breadth_histogram && Array.isArray(cd.breadth_histogram.bins) ? cd.breadth_histogram.bins.map(num) : null))
+    .filter(Boolean);
+  let breadth = null;
+  let combinable = false;
+  if (binsArr.length === cds.length && binsArr.length) {
+    const L = binsArr[0].length;
+    if (binsArr.every((b) => b.length === L)) {
+      combinable = true;
+      const bins = new Array(L).fill(0);
+      for (let i = 0; i < L; i++) {
+        let mx = 0;
+        binsArr.forEach((b) => {
+          if (b[i] > mx) mx = b[i];
+        });
+        bins[i] = mx;
+      }
+      const refBh =
+        (cds.find(({ cd }) => cd && cd.breadth_histogram && Array.isArray(cd.breadth_histogram.bins) && cd.breadth_histogram.bins.length === L) || {}).cd
+          ?.breadth_histogram || {};
+      breadth = { bins };
+      if (refBh.bin_size != null) breadth.bin_size = refBh.bin_size;
+      if (refBh.total_len != null) breadth.total_len = refBh.total_len;
+      if (Array.isArray(refBh.breaks)) breadth.breaks = refBh.breaks;
+      if (Array.isArray(refBh.contig_names)) breadth.contig_names = refBh.contig_names;
+    }
+  }
+  return Object.assign(_base, { __combinable: combinable, breadth_histogram: breadth });
+}
+// Rewrite the incoming items for the merged view: combinable specimens become a
+// single combined item; non-combinable ones expand into one item per member.
+function _covExpandMerged(raw) {
+  if (!(typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled)) return raw || [];
+  const out = [];
+  (raw || []).forEach((it) => {
+    if (!it || !it.sample) return;
+    const members = _covSpecimenMembers(it.sample);
+    if (members.length <= 1) {
+      out.push(it);
+      return;
+    }
+    const cds = _covMemberCds(it.sample, it.organism, it.taxid);
+    if (cds.length === 0) {
+      out.push(it); // no member carries coverage — leave the (empty) specimen item
+      return;
+    }
+    if (cds.length === 1) {
+      // Only one member actually has coverage data — show that member's curve
+      // rather than an empty specimen line.
+      out.push({ sample: cds[0].sample, organism: it.organism, taxid: it.taxid, __overlayOf: it.sample });
+      return;
+    }
+    const combined = _covCombineCds(cds);
+    if (combined.__combinable) {
+      out.push(Object.assign({}, it, { __mergedCd: combined, __mergedMembers: cds.map((c) => c.sample) }));
+    } else {
+      // Overlay: one line per member sample (keeps the specimen name as a hint).
+      cds.forEach(({ sample }) =>
+        out.push({ sample, organism: it.organism, taxid: it.taxid, __overlayOf: it.sample }),
+      );
+    }
+  });
+  return out;
+}
+
 function _openCoverageModal(rawItems, opts) {
   opts = opts || {};
   const ov = document.getElementById("cov-overlay");
   if (!ov) return;
+  rawItems = _covExpandMerged(rawItems);
   const seen = new Set(),
     items = [];
   (rawItems || []).forEach((it) => {
@@ -184,7 +380,13 @@ function _openCoverageModal(rawItems, opts) {
     const key = `${it.sample}||${it.organism}||${it.taxid}`;
     if (seen.has(key)) return;
     seen.add(key);
-    items.push({ sample: it.sample, organism: it.organism || "", taxid: it.taxid || "" });
+    items.push({
+      sample: it.sample,
+      organism: it.organism || "",
+      taxid: it.taxid || "",
+      __mergedCd: it.__mergedCd || null,
+      __overlayOf: it.__overlayOf || null,
+    });
   });
   const orgNames = uniq(items.map((it) => it.organism));
   const orgColor = new Map();
@@ -196,7 +398,9 @@ function _openCoverageModal(rawItems, opts) {
     // other chart. Fall back to the generic palette only for samples that
     // somehow have no assigned colour yet.
     it.color = sampleColors[it.sample] || _XS_SAMPLE_PALETTE[i % _XS_SAMPLE_PALETTE.length];
-    it.cd = _covFetch(it.sample, it.organism, it.taxid);
+    // A merged specimen uses its pre-combined synthetic coverage; overlaid
+    // member samples and plain samples fetch their own encoded data.
+    it.cd = it.__mergedCd || _covFetch(it.sample, it.organism, it.taxid);
     it.depth = it.cd ? _covDepth(it.cd) : null;
     it.profile = it.cd ? _covProfile(it.cd) : null;
   });
@@ -1672,7 +1876,82 @@ function _novPositionTip(tip, ev) {
 }
 
 function _novSamples() {
-  return (NOVELTY && NOVELTY.samples) || {};
+  const raw = (NOVELTY && NOVELTY.samples) || {};
+  const visible = Object.keys(raw).filter((s) => !(typeof sampleHidden !== "undefined" && sampleHidden[s]));
+  if (!(typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled) || typeof specimenOf !== "function") {
+    const out = {};
+    visible.forEach((s) => (out[s] = raw[s]));
+    return out;
+  }
+
+  // Fold novelty blocks over the same specimen grouping used by filteredData().
+  // Counts are summed, fractions are read-weighted/recomputed, novelty flags
+  // are ORed, and the strongest member score is retained for triage.
+  const grouped = new Map();
+  visible.forEach((s) => {
+    const g = specimenOf(s);
+    if (!grouped.has(g)) grouped.set(g, []);
+    grouped.get(g).push(s);
+  });
+  const out = {};
+  grouped.forEach((members, group) => {
+    if (members.length === 1 && group === members[0]) {
+      out[group] = raw[members[0]];
+      return;
+    }
+    const blocks = members.map((s) => raw[s] || {});
+    const summaries = blocks.map((b) => b.summary || {});
+    const total = summaries.reduce((a, sm) => a + (+sm.total_reads || 0), 0);
+    const sum = (key) => summaries.reduce((a, sm) => a + (+sm[key] || 0), 0);
+    const weighted = (key) =>
+      total
+        ? summaries.reduce((a, sm) => a + (+sm[key] || 0) * (+sm.total_reads || 0), 0) / total
+        : 0;
+    const summary = Object.assign({}, summaries[0] || {}, {
+      sample: group,
+      total_reads: total,
+      ref_aligned: sum("ref_aligned"),
+      k2_classified: sum("k2_classified"),
+      mmseqs_assigned: sum("mmseqs_assigned"),
+      mmseqs_assigned_species: sum("mmseqs_assigned_species"),
+      mmseqs_assigned_highrank: sum("mmseqs_assigned_highrank"),
+      dark_fraction: weighted("dark_fraction"),
+      highrank_only_fraction: weighted("highrank_only_fraction"),
+      lowident_tail_mass: weighted("lowident_tail_mass"),
+      novelty_score: Math.max(0, ...summaries.map((sm) => +sm.novelty_score || 0)),
+      novelty_flag: summaries.some((sm) => Number(sm.novelty_flag) === 1) ? 1 : 0,
+      __mergedFrom: members.slice(),
+    });
+    summary.ref_aligned_frac = total ? summary.ref_aligned / total : 0;
+    summary.k2_frac = total ? summary.k2_classified / total : 0;
+    summary.mmseqs_frac = total ? summary.mmseqs_assigned / total : 0;
+
+    const candMap = new Map();
+    blocks.forEach((b) => {
+      (b.candidates || []).forEach((c) => {
+        const key = [c.taxid || "", c.rank || "", (c.name || "").toLowerCase()].join("\u0001");
+        let agg = candMap.get(key);
+        if (!agg) {
+          agg = { row: Object.assign({}, c, { sample: group, reads: 0 }), highrankPool: 0 };
+          candMap.set(key, agg);
+        }
+        const reads = +c.reads || 0;
+        agg.row.reads += reads;
+        const hf = c.frac_of_highrank === "" || c.frac_of_highrank == null ? NaN : +c.frac_of_highrank;
+        if (isFinite(hf) && hf > 0) agg.highrankPool += reads / hf;
+        if (!agg.row.pathogen && c.pathogen) agg.row.pathogen = c.pathogen;
+      });
+    });
+    const candidates = Array.from(candMap.values())
+      .map((agg) => {
+        agg.row.frac_of_sample = total ? agg.row.reads / total : 0;
+        agg.row.frac_of_highrank = agg.highrankPool > 0 ? agg.row.reads / agg.highrankPool : "";
+        return agg.row;
+      })
+      .sort((a, b) => (+b.reads || 0) - (+a.reads || 0));
+    out[group] = { summary, candidates, __mergedFrom: members.slice() };
+  });
+  return out;
 }
 
 function _drawNoveltySummary() {
@@ -2126,8 +2405,19 @@ function _drawNoveltyMethodCoverage() {
 // closed-set genus rollup for one sample, from the main TASS records (BOOT.records)
 function _novClosedGenus(sample) {
   const out = {};
+  const novBlock = _novSamples()[sample] || {};
+  let memberList = Array.isArray(novBlock.__mergedFrom) ? novBlock.__mergedFrom.slice() : [sample];
+  if (
+    typeof specimenMergeEnabled !== "undefined" &&
+    specimenMergeEnabled &&
+    typeof specimenGroups === "function" &&
+    specimenGroups().has(sample)
+  ) {
+    memberList = specimenGroups().get(sample).filter((s) => !(typeof sampleHidden !== "undefined" && sampleHidden[s]));
+  }
+  const members = new Set(memberList);
   (DATA || []).forEach((r) => {
-    if ((r["Specimen ID"] || r.sample) !== sample) return;
+    if (!members.has(r["Specimen ID"] || r.sample)) return;
     const g = (r["Genus Name"] || r["Genus"] || "").trim();
     if (!g) return;
     const key = g.toLowerCase();

--- a/assets/src/js/26_resizable_right_sidebar.js
+++ b/assets/src/js/26_resizable_right_sidebar.js
@@ -71,7 +71,16 @@
          the upload / clear handlers so all three stay in sync.
       ────────────────────────────────────────────────────────────────────────── */
 function _buildBannerSub() {
-  const samples = uniq(DATA.map((r) => r["Specimen ID"] || "")).filter(Boolean);
+  const rawSamples = uniq([
+    ...DATA.map((r) => r["Specimen ID"] || ""),
+    ...Object.keys((typeof SAMPLE_META !== "undefined" && SAMPLE_META) || {}),
+  ]).filter(Boolean);
+  const grouped =
+    typeof specimenMergeEnabled !== "undefined" &&
+    specimenMergeEnabled &&
+    typeof hasSpecimenGrouping === "function" &&
+    hasSpecimenGrouping();
+  const entities = grouped ? uniq(rawSamples.map((s) => specimenOf(s))).filter(Boolean) : rawSamples;
 
   // Unique organisms: deduplicate on Taxonomic ID # (key), not subkey
   const uniqueOrgs = new Set(DATA.map((r) => r["Taxonomic ID #"] || "").filter(Boolean)).size;
@@ -79,12 +88,13 @@ function _buildBannerSub() {
   // % reads classified = Σ(total_organism_reads from SAMPLE_META) / Σ(total_reads from SAMPLE_META)
   // Uses per-sample metadata from the JSON. Falls back to summing "# Reads Aligned"
   // from DATA rows if SAMPLE_META doesn't carry total_reads (e.g. plain TSV upload).
-  const totalInputReads = samples.reduce((s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_reads) || 0), 0);
+  const totalInputReads = rawSamples.reduce((s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_reads) || 0), 0);
   const totalOrgReads =
-    samples.reduce((s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_organism_reads) || 0), 0) ||
+    rawSamples.reduce((s, sn) => s + (parseFloat((SAMPLE_META[sn] || {}).total_organism_reads) || 0), 0) ||
     DATA.reduce((s, r) => s + (parseFloat(r["# Reads Aligned"]) || 0), 0);
   let pctClass = totalInputReads > 0 ? ((totalOrgReads / totalInputReads) * 100).toFixed(1) + "%" : "N/A";
   if (pctClass === "0.0%" && totalOrgReads > 0) pctClass = "<0.1%";
+  const totalReadsFmt = _fmtBig(totalInputReads).short;
 
-  return `${samples.length} sample(s) \u2022 ${uniqueOrgs} unique organism(s) \u2022 ${pctClass} reads classified`;
+  return `${entities.length} ${grouped ? "specimen(s)" : "sample(s)"} \u2022 ${uniqueOrgs} unique organism(s) \u2022 ${pctClass} reads classified \u2022 ${totalReadsFmt} total reads`;
 }

--- a/assets/src/js/26_resizable_right_sidebar.js
+++ b/assets/src/js/26_resizable_right_sidebar.js
@@ -96,5 +96,7 @@ function _buildBannerSub() {
   if (pctClass === "0.0%" && totalOrgReads > 0) pctClass = "<0.1%";
   const totalReadsFmt = _fmtBig(totalInputReads).short;
 
-  return `${entities.length} ${grouped ? "specimen(s)" : "sample(s)"} \u2022 ${uniqueOrgs} unique organism(s) \u2022 ${pctClass} reads classified \u2022 ${totalReadsFmt} total reads`;
+  return `${entities.length} ${
+    grouped ? "specimen(s)" : "sample(s)"
+  } \u2022 ${uniqueOrgs} unique organism(s) \u2022 ${pctClass} reads classified \u2022 ${totalReadsFmt} total reads`;
 }

--- a/assets/src/js/29_session_state.js
+++ b/assets/src/js/29_session_state.js
@@ -99,6 +99,71 @@
   }
   window._ttApplyBoot = _ttApplyBoot;
 
+  // Snapshot non-form application state. These values cannot be recovered
+  // from the DOM controls and must be restored before the first final redraw.
+  function _ttCaptureAppState() {
+    var app = {};
+    try {
+      app.specimenMergeEnabled = !!specimenMergeEnabled;
+      app.specimenOverride = Object.assign({}, SPECIMEN_OVERRIDE || {});
+      app.specimenMetaResolved = Object.assign({}, SPECIMEN_META_RESOLVED || {});
+    } catch (e) {}
+    try {
+      app.sampleOrder = Array.isArray(_sampleOrder) ? _sampleOrder.slice() : [];
+      app.sampleHidden = Object.assign({}, sampleHidden || {});
+      app.sampleRescale = Object.assign({}, sampleRescale || {});
+      app.perTypeTass = Object.assign({}, perTypeTass || {});
+      app.sampleListPage = typeof _sampleListPage === "number" ? _sampleListPage : 0;
+    } catch (e) {}
+    try {
+      app.watchlist = Array.from(watchlist || []);
+      app.watchFilterMode = watchFilterMode;
+    } catch (e) {}
+    try {
+      app.sortCol = sortCol;
+      app.sortAsc = sortAsc;
+    } catch (e) {}
+    return app;
+  }
+
+  function _ttReplaceObject(target, source) {
+    if (!target) return;
+    Object.keys(target).forEach(function (k) {
+      delete target[k];
+    });
+    Object.assign(target, source && typeof source === "object" ? source : {});
+  }
+
+  function _ttRestoreAppState(app) {
+    app = app && typeof app === "object" ? app : {};
+    try {
+      _ttReplaceObject(SPECIMEN_OVERRIDE, app.specimenOverride);
+      _ttReplaceObject(SPECIMEN_META_RESOLVED, app.specimenMetaResolved);
+      specimenMergeEnabled = !!app.specimenMergeEnabled;
+    } catch (e) {}
+    try {
+      _ttReplaceObject(sampleHidden, app.sampleHidden);
+      _ttReplaceObject(sampleRescale, app.sampleRescale);
+      _ttReplaceObject(perTypeTass, app.perTypeTass);
+      _sampleOrder = Array.isArray(app.sampleOrder) ? app.sampleOrder.slice() : [];
+      _sampleListPage = Number.isFinite(Number(app.sampleListPage)) ? Math.max(0, Number(app.sampleListPage)) : 0;
+    } catch (e) {}
+    try {
+      watchlist.clear();
+      (Array.isArray(app.watchlist) ? app.watchlist : []).forEach(function (k) {
+        watchlist.add(k);
+      });
+      watchFilterMode = typeof app.watchFilterMode === "string" ? app.watchFilterMode : "all";
+    } catch (e) {}
+    try {
+      sortCol = app.sortCol != null ? app.sortCol : null;
+      sortAsc = app.sortAsc !== false;
+    } catch (e) {}
+    try {
+      if (typeof _invalidateFilterCache === "function") _invalidateFilterCache();
+    } catch (e) {}
+  }
+
   // ── Snapshot every id'd form control + sample colors + active tab ──────
   function _ttCaptureUi() {
     var ui = { controls: {}, sampleColors: {}, activeTab: null };
@@ -137,6 +202,12 @@
     var minEl = document.getElementById("filter-min");
     var rangeEl = document.getElementById("filter-min-range");
     if (minEl && rangeEl) rangeEl.value = minEl.value;
+    // Rebuild after restoring the samples-per-page/search controls and all
+    // non-DOM sample state, so pagination, colors, visibility and grouping
+    // are correct on the first rendered frame.
+    try {
+      if (typeof buildSampleList === "function") buildSampleList();
+    } catch (e) {}
     // Re-apply filters / rerender.
     try {
       if (typeof buildTable === "function") buildTable();
@@ -187,10 +258,11 @@
       };
       var state = {
         __taxtriage_state__: true,
-        version: 1,
+        version: 2,
         exported_at: new Date().toISOString(),
         boot: boot,
         ui: _ttCaptureUi(),
+        app: _ttCaptureAppState(),
       };
       var json = JSON.stringify(state);
       var blob = new Blob([json], { type: "application/json" });
@@ -217,7 +289,23 @@
     var boot = state.boot || (Array.isArray(state.records) ? state : null);
     if (!boot) throw new Error("State file has no data payload");
     _ttApplyBoot(boot);
+    _ttRestoreAppState(state.app);
     if (state.ui) _ttRestoreUi(state.ui);
+    else {
+      try {
+        if (typeof buildSampleList === "function") buildSampleList();
+        if (typeof redraw === "function") redraw();
+      } catch (e) {}
+    }
+    try {
+      if (window.specimenMerge && typeof window.specimenMerge.refreshBar === "function") {
+        window.specimenMerge.refreshBar();
+      }
+      if (typeof _rebuildMapMarkers === "function") _rebuildMapMarkers();
+      if (typeof _buildRunMetaTable === "function") _buildRunMetaTable();
+      var bannerSub = document.getElementById("banner-sub");
+      if (bannerSub && typeof _buildBannerSub === "function") bannerSub.textContent = _buildBannerSub();
+    } catch (e) {}
   };
 
   // ── Read a state JSON file from the sidebar <input type=file> ─────────

--- a/assets/src/js/32_longitudinal_second.js
+++ b/assets/src/js/32_longitudinal_second.js
@@ -931,7 +931,11 @@ function _buildRunMetaTable() {
           ? ` contenteditable="true" spellcheck="false" data-meta-idx="${i}" data-meta-key="${k}"`
           : "";
         const dispEsc = String(disp).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-        return `<td${cls}${editAttrs} style="padding:5px 10px;border-bottom:1px solid #ddd;color:#222;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${title}">${dispEsc}</td>`;
+        const mergedBadge =
+          k === "sample_name" && typeof _mergedSampleBadgeHTML === "function"
+            ? _mergedSampleBadgeHTML(rec.sample_name)
+            : "";
+        return `<td${cls}${editAttrs} style="padding:5px 10px;border-bottom:1px solid #ddd;color:#222;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${title}">${dispEsc}${mergedBadge}</td>`;
       })
       .join("");
     return `<tr id="runmeta-row-${CSS.escape(

--- a/assets/src/js/33_categorical_metadata.js
+++ b/assets/src/js/33_categorical_metadata.js
@@ -16,6 +16,41 @@ const _META_METRIC_LABELS = {
 const _GEO_META_FIELDS = ["sample_origin_country", "sample_origin_state_province_territory"];
 const _HOST_META_FIELDS = ["host_scientific_name", "host_disease", "environmental_site"];
 
+function _metaViewId(sample) {
+  return typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled && typeof specimenOf === "function"
+    ? specimenOf(sample)
+    : sample;
+}
+
+// Resolve raw RUN_META rows into the identities currently displayed by the
+// report. Values are unioned for grouped specimens unless the merge dialog
+// stored an explicit resolution for that field.
+function _metaValuesByEntity(field) {
+  const by = {};
+  (RUN_META || []).forEach((r) => {
+    if (sampleHidden[r.sample_name]) return;
+    const id = _metaViewId(r.sample_name);
+    const v = r[field];
+    const vals = v == null ? [] : Array.isArray(v) ? v : [v];
+    if (!by[id]) by[id] = new Set();
+    vals.forEach((x) => {
+      const s = String(x).trim();
+      if (s) by[id].add(s);
+    });
+  });
+  Object.keys(by).forEach((id) => {
+    const resolved =
+      typeof SPECIMEN_META_RESOLVED !== "undefined" && SPECIMEN_META_RESOLVED[id]
+        ? SPECIMEN_META_RESOLVED[id][field]
+        : null;
+    if (resolved != null && resolved !== "") {
+      const vals = Array.isArray(resolved) ? resolved : [resolved];
+      by[id] = new Set(vals.map((x) => String(x).trim()).filter(Boolean));
+    }
+  });
+  return Object.fromEntries(Object.entries(by).map(([id, vals]) => [id, Array.from(vals)]));
+}
+
 // True if any RUN_META record has a non-empty value for one of `fields`.
 function _anyMetaValue(fields) {
   return (RUN_META || []).some((r) =>
@@ -35,14 +70,8 @@ function _aggregateMetaByField(fieldKey, metric, sampleSet) {
   // sample_name → array of categorical values (always an array for uniform handling)
   // sampleSet (optional): restrict to these sample_names (used when drilling
   // into a single country's states).
-  const valBy = {};
-  (RUN_META || []).forEach((r) => {
-    if (sampleSet && !sampleSet.has(r.sample_name)) return;
-    const v = r[fieldKey];
-    if (v == null) return;
-    const vals = Array.isArray(v) ? v.map((s) => String(s).trim()).filter(Boolean) : [String(v).trim()].filter(Boolean);
-    if (vals.length) valBy[r.sample_name] = vals;
-  });
+  const valBy = _metaValuesByEntity(fieldKey);
+  if (sampleSet) Object.keys(valBy).forEach((id) => !sampleSet.has(id) && delete valBy[id]);
   if (!Object.keys(valBy).length) return [];
 
   const groups = {};
@@ -50,9 +79,10 @@ function _aggregateMetaByField(fieldKey, metric, sampleSet) {
     (groups[val] = groups[val] || { samples: new Set(), detections: 0, reads: 0, tassSum: 0, tassN: 0 });
 
   if (metric === "samples") {
-    // Count visible (non-hidden) samples per category value
+    // Count only entities represented by the current filtered detections.
+    const visibleEntities = new Set(filteredData().map((r) => r["Specimen ID"] || "").filter(Boolean));
     Object.entries(valBy).forEach(([s, vals]) => {
-      if (sampleHidden[s]) return;
+      if (!visibleEntities.has(s)) return;
       vals.forEach((val) => ensure(val).samples.add(s));
     });
   } else {
@@ -536,13 +566,11 @@ window._ttAutofillGeoFromCoords = _ttAutofillGeoFromCoords;
 function _geoSamplesForDatum(field, datumLabel) {
   const keys = new Set(_geoMatchKeys(field, datumLabel));
   const set = new Set();
-  (RUN_META || []).forEach((r) => {
-    const v = r[field];
-    const vals = v == null ? [] : Array.isArray(v) ? v : [v];
+  Object.entries(_metaValuesByEntity(field)).forEach(([id, vals]) => {
     for (const x of vals) {
       for (const k of _geoMatchKeys(field, x)) {
         if (keys.has(k)) {
-          set.add(r.sample_name);
+          set.add(id);
           break;
         }
       }
@@ -553,11 +581,9 @@ function _geoSamplesForDatum(field, datumLabel) {
 // Tally a metadata field's values across a set of samples → sorted [label,count].
 function _geoMetaTally(sampleSet, field) {
   const m = {};
-  (RUN_META || []).forEach((r) => {
-    if (!sampleSet.has(r.sample_name)) return;
-    const v = r[field];
-    if (v == null) return;
-    (Array.isArray(v) ? v : [v]).forEach((x) => {
+  Object.entries(_metaValuesByEntity(field)).forEach(([id, vals]) => {
+    if (!sampleSet.has(id)) return;
+    vals.forEach((x) => {
       const s = String(x).trim();
       if (s) m[s] = (m[s] || 0) + 1;
     });
@@ -656,7 +682,7 @@ function _geoRegionInfoHTML(field, label, opts) {
   if (!isCountry) {
     const cs = new Set();
     (RUN_META || []).forEach((r) => {
-      if (!sset.has(r.sample_name)) return;
+      if (!sset.has(_metaViewId(r.sample_name))) return;
       const c = String(r.sample_origin_country == null ? "" : r.sample_origin_country).trim();
       if (c) cs.add(c);
     });
@@ -894,18 +920,20 @@ function _aggregateMetaNested(parentField, childField, metric) {
       ? v.map((x) => String(x).trim()).filter(Boolean)
       : [String(v).trim()].filter(Boolean);
   const recBy = {};
-  (RUN_META || []).forEach((r) => {
-    const p = toArr(r[parentField]);
-    if (!p.length) return;
-    recBy[r.sample_name] = { parents: p, children: toArr(r[childField]) };
+  const parentsBy = _metaValuesByEntity(parentField);
+  const childrenBy = _metaValuesByEntity(childField);
+  Object.keys(parentsBy).forEach((id) => {
+    const p = toArr(parentsBy[id]);
+    if (p.length) recBy[id] = { parents: p, children: toArr(childrenBy[id]) };
   });
   const parents = {};
   const eP = (p) =>
     (parents[p] = parents[p] || { samples: new Set(), detections: 0, reads: 0, tassSum: 0, tassN: 0, kids: {} });
   const eK = (P, c) => (P.kids[c] = P.kids[c] || { samples: new Set(), detections: 0, reads: 0, tassSum: 0, tassN: 0 });
   if (metric === "samples") {
+    const visibleEntities = new Set(filteredData().map((r) => r["Specimen ID"] || "").filter(Boolean));
     Object.entries(recBy).forEach(([s, o]) => {
-      if (sampleHidden[s]) return;
+      if (!visibleEntities.has(s)) return;
       o.parents.forEach((p) => {
         const P = eP(p);
         P.samples.add(s);
@@ -1383,9 +1411,9 @@ function _hostMatrixData(symField, orgField) {
       ? v.map((x) => String(x).trim()).filter(Boolean)
       : [String(v).trim()].filter(Boolean);
   const symBy = {};
-  (RUN_META || []).forEach((r) => {
-    const vals = toArr(r[symField]);
-    if (vals.length) symBy[r.sample_name] = vals;
+  Object.entries(_metaValuesByEntity(symField)).forEach(([id, raw]) => {
+    const vals = toArr(raw);
+    if (vals.length) symBy[id] = vals;
   });
   if (!Object.keys(symBy).length) return null;
   // sample → set of detected organisms (visible detections only)

--- a/assets/src/js/33_categorical_metadata.js
+++ b/assets/src/js/33_categorical_metadata.js
@@ -80,7 +80,11 @@ function _aggregateMetaByField(fieldKey, metric, sampleSet) {
 
   if (metric === "samples") {
     // Count only entities represented by the current filtered detections.
-    const visibleEntities = new Set(filteredData().map((r) => r["Specimen ID"] || "").filter(Boolean));
+    const visibleEntities = new Set(
+      filteredData()
+        .map((r) => r["Specimen ID"] || "")
+        .filter(Boolean),
+    );
     Object.entries(valBy).forEach(([s, vals]) => {
       if (!visibleEntities.has(s)) return;
       vals.forEach((val) => ensure(val).samples.add(s));
@@ -931,7 +935,11 @@ function _aggregateMetaNested(parentField, childField, metric) {
     (parents[p] = parents[p] || { samples: new Set(), detections: 0, reads: 0, tassSum: 0, tassN: 0, kids: {} });
   const eK = (P, c) => (P.kids[c] = P.kids[c] || { samples: new Set(), detections: 0, reads: 0, tassSum: 0, tassN: 0 });
   if (metric === "samples") {
-    const visibleEntities = new Set(filteredData().map((r) => r["Specimen ID"] || "").filter(Boolean));
+    const visibleEntities = new Set(
+      filteredData()
+        .map((r) => r["Specimen ID"] || "")
+        .filter(Boolean),
+    );
     Object.entries(recBy).forEach(([s, o]) => {
       if (!visibleEntities.has(s)) return;
       o.parents.forEach((p) => {

--- a/assets/src/js/35_tab_map.js
+++ b/assets/src/js/35_tab_map.js
@@ -138,9 +138,7 @@ function _addMapClusterControl() {
 function _addSampleMarkers() {
   const geoRows = RUN_META.filter((r) => r.latitude != null && r.longitude != null);
   const mergeOn =
-    typeof specimenMergeEnabled !== "undefined" &&
-    specimenMergeEnabled &&
-    typeof specimenOf === "function";
+    typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled && typeof specimenOf === "function";
   const markerRows = [];
   if (mergeOn) {
     const bySpec = new Map();

--- a/assets/src/js/35_tab_map.js
+++ b/assets/src/js/35_tab_map.js
@@ -137,13 +137,47 @@ function _addMapClusterControl() {
    bounds for fitting the view. */
 function _addSampleMarkers() {
   const geoRows = RUN_META.filter((r) => r.latitude != null && r.longitude != null);
-  const sampleNames = [...new Set(geoRows.map((r) => r.sample_name))];
+  const mergeOn =
+    typeof specimenMergeEnabled !== "undefined" &&
+    specimenMergeEnabled &&
+    typeof specimenOf === "function";
+  const markerRows = [];
+  if (mergeOn) {
+    const bySpec = new Map();
+    geoRows.forEach((r) => {
+      const spec = specimenOf(r.sample_name);
+      if (!bySpec.has(spec)) bySpec.set(spec, []);
+      bySpec.get(spec).push(r);
+    });
+    bySpec.forEach((recs, spec) => {
+      if (recs.length === 1 && spec === recs[0].sample_name) {
+        markerRows.push(recs[0]);
+        return;
+      }
+      const resolved =
+        typeof SPECIMEN_META_RESOLVED !== "undefined" && SPECIMEN_META_RESOLVED[spec]
+          ? SPECIMEN_META_RESOLVED[spec]
+          : {};
+      const rec = Object.assign({}, recs[0], resolved, {
+        sample_name: spec,
+        __mergedMembers:
+          typeof specimenGroups === "function" && specimenGroups().has(spec)
+            ? specimenGroups().get(spec).slice()
+            : recs.map((r) => r.sample_name),
+      });
+      markerRows.push(rec);
+    });
+  } else {
+    markerRows.push(...geoRows);
+  }
+
+  const sampleNames = [...new Set(markerRows.map((r) => r.sample_name))];
   sampleNames.forEach((n, i) => {
     if (!sampleColors[n]) sampleColors[n] = PALETTE[i % PALETTE.length];
   });
 
   const bounds = [];
-  geoRows.forEach((rec) => {
+  markerRows.forEach((rec) => {
     const lat = parseFloat(rec.latitude);
     const lon = parseFloat(rec.longitude);
     if (isNaN(lat) || isNaN(lon)) return;
@@ -159,8 +193,9 @@ function _addSampleMarkers() {
       _refreshMapMarkerColors();
       _renderMapPanel(rec);
     });
-    _markerObjects[sn] = { marker: mk, rec, color, lat, lon };
-    if (!sampleHidden[sn]) _markerLayer.addLayer(mk);
+    const members = Array.isArray(rec.__mergedMembers) ? rec.__mergedMembers : [sn];
+    _markerObjects[sn] = { marker: mk, rec, color, lat, lon, members };
+    if (!members.every((s) => sampleHidden[s])) _markerLayer.addLayer(mk);
     bounds.push([lat, lon]);
   });
   return bounds;
@@ -170,7 +205,8 @@ function _refreshMapMarkerColors() {
   if (!_markerObjects || !_leafletMap || !_markerLayer) return;
   Object.entries(_markerObjects).forEach(([sn, obj]) => {
     if (!obj.marker) return;
-    if (sampleHidden[sn]) {
+    const members = Array.isArray(obj.members) && obj.members.length ? obj.members : [sn];
+    if (members.every((s) => sampleHidden[s])) {
       if (_markerLayer.hasLayer(obj.marker)) _markerLayer.removeLayer(obj.marker);
       return;
     }
@@ -389,14 +425,14 @@ function _renderMapPanel(rec) {
   // Show the "View in metadata table" button only if runmeta tab is available
   const viewBtn = document.getElementById("map-panel-view-btn");
   if (viewBtn) {
-    const hasRunMeta = RUN_META.length > 0;
+    const hasRunMeta = RUN_META.length > 0 && !Array.isArray(rec.__mergedMembers);
     viewBtn.style.display = hasRunMeta ? "inline-block" : "none";
   }
 
   // Meta info strip — show lat/lon first, then all other non-null fields dynamically
   const metaEl = document.getElementById("map-panel-meta");
   if (metaEl) {
-    const skip = new Set(["sample_name", "latitude", "longitude"]);
+    const skip = new Set(["sample_name", "latitude", "longitude", "__mergedMembers"]);
     const lines = [];
 
     // Lat/Lon always first (it's why the dot is on the map)

--- a/assets/src/js/36_guided_help_tour.js
+++ b/assets/src/js/36_guided_help_tour.js
@@ -473,22 +473,472 @@
     else if (e.key === "ArrowLeft") show(idx - 1);
   });
 
+  /* ══════════════════════════════════════════════════════════════════════
+     SPOTLIGHT WALKTHROUGH ENGINE
+        A reusable stepped highlighter modelled on the attached report: a dim
+        backdrop, a glowing ring that moves to each target (measured live from
+        getBoundingClientRect) and a compact popover pinned next to it with
+        Back / Next / dots. Used by per-tab Help mode and the right-panel "?"
+        button. Leaves the little bottom-left #tab-help-panel visible on top.
+     ══════════════════════════════════════════════════════════════════════ */
+  const Spotlight = (function () {
+    let dim, ring, pop, popIco, popTitle, popStep, popBody, popTips, popDots, btnBack, btnNext, btnClose;
+    let steps = [],
+      idx = 0,
+      target = null,
+      onExit = null,
+      built = false,
+      reposition = null,
+      settleTimer = null;
+
+    function build() {
+      if (built) return;
+      built = true;
+      dim = document.createElement("div");
+      dim.id = "hs-dim";
+      ring = document.createElement("div");
+      ring.id = "hs-ring";
+      pop = document.createElement("div");
+      pop.id = "hs-pop";
+      pop.setAttribute("role", "dialog");
+      pop.innerHTML =
+        '<div id="hs-pop-head"><span id="hs-pop-ico"><i class="fas fa-circle-question"></i></span>' +
+        '<h4 id="hs-pop-title"></h4><span id="hs-pop-step"></span>' +
+        '<button id="hs-pop-x" type="button" title="Close" aria-label="Close help">&times;</button></div>' +
+        '<div id="hs-pop-body"></div><ul id="hs-pop-tips"></ul>' +
+        '<div id="hs-pop-foot"><div id="hs-pop-dots"></div><span class="hs-spacer"></span>' +
+        '<button id="hs-back" type="button"><i class="fas fa-arrow-left"></i> Back</button>' +
+        '<button id="hs-next" type="button">Next <i class="fas fa-arrow-right"></i></button></div>';
+      document.body.appendChild(dim);
+      document.body.appendChild(ring);
+      document.body.appendChild(pop);
+      popIco = pop.querySelector("#hs-pop-ico");
+      popTitle = pop.querySelector("#hs-pop-title");
+      popStep = pop.querySelector("#hs-pop-step");
+      popBody = pop.querySelector("#hs-pop-body");
+      popTips = pop.querySelector("#hs-pop-tips");
+      popDots = pop.querySelector("#hs-pop-dots");
+      btnBack = pop.querySelector("#hs-back");
+      btnNext = pop.querySelector("#hs-next");
+      btnClose = pop.querySelector("#hs-pop-x");
+      btnBack.addEventListener("click", () => go(idx - 1));
+      btnNext.addEventListener("click", () => (idx >= steps.length - 1 ? stop() : go(idx + 1)));
+      btnClose.addEventListener("click", stop);
+      dim.addEventListener("click", stop);
+      popDots.addEventListener("click", (e) => {
+        const d = e.target.closest(".hs-dot");
+        if (d) go(parseInt(d.dataset.i, 10));
+      });
+      document.addEventListener("keydown", (e) => {
+        if (!isOpen()) return;
+        if (e.key === "Escape") stop();
+        else if (e.key === "ArrowRight") idx >= steps.length - 1 ? stop() : go(idx + 1);
+        else if (e.key === "ArrowLeft") go(idx - 1);
+      });
+    }
+
+    function isOpen() {
+      return built && dim.classList.contains("show");
+    }
+    // first selector that exists (visible preferred); sel may be string or array
+    function resolve(sel) {
+      if (!sel) return null;
+      const list = Array.isArray(sel) ? sel : [sel];
+      for (const s of list) {
+        const el = document.querySelector(s);
+        if (el && el.offsetParent !== null) return el;
+      }
+      for (const s of list) {
+        const el = document.querySelector(s);
+        if (el) return el;
+      }
+      return null;
+    }
+    function clearTarget() {
+      if (target) {
+        target.classList.remove("hs-target");
+        target = null;
+      }
+    }
+    function place() {
+      if (!target) {
+        ring.style.display = "none";
+        return;
+      }
+      const r = target.getBoundingClientRect();
+      const pad = 6;
+      ring.style.display = "block";
+      ring.style.top = r.top - pad + "px";
+      ring.style.left = r.left - pad + "px";
+      ring.style.width = r.width + pad * 2 + "px";
+      ring.style.height = r.height + pad * 2 + "px";
+      const pw = pop.offsetWidth || 320,
+        ph = pop.offsetHeight || 210,
+        gap = 16,
+        vw = window.innerWidth,
+        vh = window.innerHeight;
+      let left,
+        top,
+        beside = true;
+      if (r.right + gap + pw <= vw) left = r.right + gap; // right of target
+      else if (r.left - gap - pw >= 0) left = r.left - gap - pw; // left of target
+      else {
+        beside = false;
+        left = Math.max(8, Math.min(vw - pw - 8, r.left));
+      }
+      if (beside) top = r.top + r.height / 2 - ph / 2;
+      else top = r.bottom + gap + ph <= vh ? r.bottom + gap : r.top - gap - ph;
+      top = Math.max(8, Math.min(vh - ph - 8, top));
+      pop.style.left = left + "px";
+      pop.style.top = top + "px";
+    }
+    function render() {
+      const s = steps[idx];
+      if (!s) return;
+      clearTarget();
+      target = resolve(s.sel);
+      if (target) {
+        target.classList.add("hs-target");
+        try {
+          target.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });
+        } catch (e) {}
+      }
+      popIco.innerHTML = `<i class="fas ${s.icon || "fa-circle-dot"}"></i>`;
+      popTitle.textContent = s.title || "";
+      popStep.textContent = `${idx + 1} / ${steps.length}`;
+      popBody.innerHTML = s.desc || "";
+      popTips.innerHTML = (s.tips || []).map((t) => `<li>${t}</li>`).join("");
+      popDots.innerHTML = steps
+        .map((_, i) => `<span class="hs-dot${i === idx ? " on" : ""}" data-i="${i}"></span>`)
+        .join("");
+      btnBack.disabled = idx === 0;
+      btnNext.innerHTML =
+        idx >= steps.length - 1 ? 'Done <i class="fas fa-check"></i>' : 'Next <i class="fas fa-arrow-right"></i>';
+      requestAnimationFrame(place);
+      clearTimeout(settleTimer);
+      settleTimer = setTimeout(place, 360); // re-measure after the smooth scroll settles
+    }
+    function go(i) {
+      idx = Math.max(0, Math.min(steps.length - 1, i));
+      render();
+    }
+    function start(stepList, opts) {
+      opts = opts || {};
+      build();
+      const resolved = (stepList || []).filter((s) => resolve(s.sel));
+      if (!resolved.length) return false;
+      steps = resolved;
+      idx = 0;
+      onExit = opts.onExit || null;
+      document.body.classList.add("hs-open");
+      dim.classList.add("show");
+      ring.classList.add("show");
+      pop.classList.add("show");
+      if (!reposition) {
+        reposition = () => {
+          if (isOpen()) place();
+        };
+        window.addEventListener("resize", reposition);
+        window.addEventListener("scroll", reposition, true);
+      }
+      render();
+      return true;
+    }
+    function stop() {
+      if (!built) return;
+      clearTarget();
+      dim.classList.remove("show");
+      ring.classList.remove("show");
+      pop.classList.remove("show");
+      document.body.classList.remove("hs-open");
+      const cb = onExit;
+      onExit = null;
+      if (cb) cb();
+    }
+    return { start, stop, isOpen };
+  })();
+
+  // ── Major-area step lists for each tab (the per-tab Help-mode walkthrough) ──
+  const TAB_AREAS = {
+    summary: [
+      {
+        sel: "#summary-kpi-row",
+        icon: "fa-gauge-high",
+        title: "Headline KPIs",
+        desc: "At-a-glance totals for the run — samples, detections and the recommended TASS cutoff.",
+        tips: ["These recompute live as you filter samples in the right panel."],
+      },
+      {
+        sel: "#sum-inner-tabs",
+        icon: "fa-folder-tree",
+        title: "Summary sub-views",
+        desc: "Switch between <b>Detections</b>, <b>Genera</b>, <b>VF/AMR</b> and <b>Cross-Sample</b> without leaving this tab.",
+        tips: ["Each sub-view answers a different first-look question."],
+      },
+      {
+        sel: "#watch-panel",
+        icon: "fa-star",
+        title: "Follow-up watchlist",
+        desc: "Star organisms here to flag them; the star markers then appear across every other tab.",
+        tips: ["Use it to build a shortlist while you triage."],
+      },
+    ],
+    heatmap: [
+      {
+        sel: "#pane-heatmap .tab-controls",
+        icon: "fa-sliders",
+        title: "Metric & scaling",
+        desc: "Choose the value shown (TASS, reads, coverage…), the taxonomic rank, colour scaling and whether cells print their value.",
+        tips: ["Log / sqrt scaling helps when a few cells dominate."],
+      },
+      {
+        sel: "#heatmap-svg-wrap",
+        icon: "fa-th",
+        title: "Samples × organisms grid",
+        desc: "Each cell is one organism in one sample; darker = higher. The fastest way to spot shared vs unique organisms.",
+        tips: ["Hover any cell for the exact value."],
+      },
+    ],
+    tass: [
+      {
+        sel: "#pane-tass .tab-controls",
+        icon: "fa-sliders",
+        title: "Comparison controls",
+        desc: "Set the rank, colour scaling, taxonomic level and whether the per-sample-type cutoff line is drawn.",
+        tips: ["Toggle the cutoff to see which calls clear the threshold."],
+      },
+      {
+        sel: "#tass-svg-wrap",
+        icon: "fa-chart-bar",
+        title: "TASS chart",
+        desc: "Confidence scores side-by-side, coloured by sample using the same colours as the right panel.",
+        tips: [],
+      },
+    ],
+    sunburst: [
+      {
+        sel: "#sun-metric",
+        icon: "fa-sliders",
+        title: "Sizing metric",
+        desc: "Pick which metric sizes the wedges — reads, TASS, coverage and so on.",
+        tips: [],
+      },
+      {
+        sel: "#sun-panels-container",
+        icon: "fa-circle-nodes",
+        title: "Radial taxonomy",
+        desc: "Inner rings are higher ranks (kingdom→genus), outer rings species/strains. Click a wedge to zoom in; click the centre to zoom out.",
+        tips: ["Add a panel to compare two samples side-by-side."],
+      },
+    ],
+    coverage: [
+      {
+        sel: "#pane-coverage .tab-controls",
+        icon: "fa-sliders",
+        title: "Axes & scaling",
+        desc: "Choose what the X, Y and bubble-size axes represent, plus the colour scaling.",
+        tips: ["High reads + low breadth outliers jump out here."],
+      },
+      {
+        sel: "#coverage-svg-wrap",
+        icon: "fa-layer-group",
+        title: "Coverage scatter",
+        desc: "Each point is a detection, coloured by its sample. Open a point's comparison to overlay genome-position profiles.",
+        tips: [],
+      },
+    ],
+    proteins: [
+      {
+        sel: "#prot-genus-wrap",
+        icon: "fa-dna",
+        title: "VF / AMR by genus",
+        desc: "Virulence-factor, AMR and transporter gene hits summarised as charts.",
+        tips: ["Click a bar to filter the table below to those hits."],
+      },
+      {
+        sel: "#prot-table-wrap",
+        icon: "fa-table",
+        title: "Gene table",
+        desc: "The searchable per-gene table. Click a row for the detailed panel.",
+        tips: [],
+      },
+    ],
+    histogram: [
+      {
+        sel: "#hist-controls",
+        icon: "fa-sliders",
+        title: "Sample selector",
+        desc: "Pick the sample to redraw its per-contig / per-assembly read-distribution histograms.",
+        tips: ["A warning icon flags uneven or sparse coverage."],
+      },
+      {
+        sel: "#pane-histogram",
+        icon: "fa-chart-column",
+        title: "Read distributions",
+        desc: "Shows how sequencing depth is spread across each genome.",
+        tips: [],
+      },
+    ],
+    explore: [
+      {
+        sel: "#pane-explore .tab-controls",
+        icon: "fa-sliders",
+        title: "Build a comparison",
+        desc: "Choose the colour-by, size-by and scaling to slice the run across any metrics you like.",
+        tips: ["Good for hunting batch effects or sample-type trends."],
+      },
+      {
+        sel: "#explore-bubble-wrap",
+        icon: "fa-magnifying-glass-chart",
+        title: "Exploratory charts",
+        desc: "Cross-sample bubble and radar views for spotting multi-metric patterns.",
+        tips: [],
+      },
+    ],
+    table: [
+      {
+        sel: "#tbl-toolbar",
+        icon: "fa-sliders",
+        title: "Table toolbar",
+        desc: "Search, choose columns and export the raw detections that sit behind every chart.",
+        tips: ["Sort by clicking a column header."],
+      },
+      {
+        sel: "#pane-table",
+        icon: "fa-table",
+        title: "Detections table",
+        desc: "Every detection row. Pin rows, then open Compare to overlay their coverage profiles.",
+        tips: [],
+      },
+    ],
+    runmeta: [
+      {
+        sel: "#runmeta-toolbar",
+        icon: "fa-sliders",
+        title: "Metadata toolbar",
+        desc: "Edit per-sample details and upload a metadata CSV to enrich the fields.",
+        tips: [],
+      },
+      {
+        sel: "#pane-runmeta",
+        icon: "fa-map-location-dot",
+        title: "Metadata & mapping",
+        desc: "Per-sample type/platform table plus a Mapping & Geography sub-tab that plots samples by coordinates or aggregated by country / state.",
+        tips: ["A sample's View button jumps here and highlights its row."],
+      },
+    ],
+  };
+
+  // ── Right-panel walkthrough (the inline "?" button next to Export Report) ──
+  const SIDEBAR_STEPS = [
+    {
+      sel: ["#report-pdf-btn", "#sidebar h3"],
+      icon: "fa-file-pdf",
+      title: "Filters & Export",
+      desc: "This right panel drives the entire report. <b>Export Report PDF</b> captures the current filtered state as a printable layout.",
+      tips: ["Every filter you set here applies across all tabs at once."],
+    },
+    {
+      sel: ["#filter-search-box", "#filter-text"],
+      icon: "fa-magnifying-glass",
+      title: "Search",
+      desc: "Filter by <b>Sample</b> or <b>Organism</b>. Plain words do a substring match; power users can use regex.",
+      tips: ["Use the options toggle to set the scope and case-sensitivity."],
+    },
+    {
+      sel: ["#per-type-tass-wrap", "#filter-min-wrap"],
+      icon: "fa-crosshairs",
+      title: "Confidence cutoff",
+      desc: "Set the minimum TASS score. Detections below the cutoff drop out of every view.",
+      tips: ["Per-sample-type cutoffs can be set independently."],
+    },
+    {
+      sel: ["#filter-kingdom-wrap", "#filter-mc", "#filter-mt-dna"],
+      icon: "fa-filter",
+      title: "More filters",
+      desc: "Narrow by kingdom, molecular type (DNA / RNA), high-confidence only and other toggles.",
+      tips: [],
+    },
+    {
+      sel: ["#toggle-all-samples-btn", "#sidebar"],
+      icon: "fa-palette",
+      title: "Samples & colours",
+      desc: "Show or hide individual samples, and click a sample's colour swatch to recolour it — that colour then follows the sample across the heatmap, charts and coverage profiles.",
+      tips: ["Toggle a sample off to drop it from every view at once."],
+    },
+    {
+      sel: ["#specimen-merge-bar", "#specimen-merge-toggle"],
+      icon: "fa-object-group",
+      title: "Group samples into a specimen",
+      desc: "Turn on <b>Specimen</b> mode to merge related samples (e.g. replicates or timepoints) into one specimen. <b>Group selected</b> combines the ones you tick; <b>Combine all</b> rolls everything into a single specimen.",
+      tips: [
+        "Grouped samples share a row and colour across every tab.",
+        "The count shows how many specimens are currently defined.",
+      ],
+    },
+    {
+      sel: ["#sample-list", "#sample-list-tools"],
+      icon: "fa-pen",
+      title: "Edit & rename samples",
+      desc: 'Each sample row has a <i class="fas fa-pen"></i> pencil to rename it and controls to attach files. Renames and edits flow through to every chart, table and export.',
+      tips: [
+        "Use the search box above the list to find a sample fast.",
+        "Page through long sample lists with the ‹ › arrows.",
+      ],
+    },
+    {
+      sel: ["#upload-zone", "#file-upload-input"],
+      icon: "fa-file-arrow-up",
+      title: "Load run data (JSON)",
+      desc: "Drop or browse for <code>all.samples.json</code>, <code>.paths.json</code>, <code>.xlsx</code>, <code>.tsv</code> or <code>.txt</code> files to load a run into this report. A metadata CSV can be added just below to enrich sample fields.",
+      tips: [
+        "Loaded data merges into the current view — filters still apply.",
+        "Clear uploaded data to return to the bundled run.",
+      ],
+    },
+    {
+      sel: ["#state-io-row", "#state-load-input"],
+      icon: "fa-floppy-disk",
+      title: "Save / load state",
+      desc: "<b>Export State</b> saves a self-contained snapshot of the current data <em>and</em> every filter, grouping and colour choice as a JSON file. <b>Load State</b> reopens one to return to exactly this view.",
+      tips: [
+        "Great for sharing an annotated view with a colleague.",
+        "State files reload offline — no pipeline rerun needed.",
+      ],
+    },
+  ];
+
   /* ── Per-tab Help mode ───────────────────────────────────────────────
            A toggle that pins a small contextual panel showing help for whatever
-           tab the user is on. Reuses the guided-tour STEP content + the PDF
-           section groups, and follows tab switches live. */
+           tab the user is on, and runs the stepped Spotlight walkthrough over
+           that tab's major areas. The right-panel "?" button reuses the same
+           machinery, scoped to the sidebar. */
   (function initHelpMode() {
     const btn = document.getElementById("helpmode-btn");
     const panel = document.getElementById("tab-help-panel");
     if (!btn || !panel) return;
+    const sideBtn = document.getElementById("sidebar-help-btn");
     const elFig = document.getElementById("tab-help-fig");
     const elGroup = document.getElementById("tab-help-group");
+    const elEyebrow = document.getElementById("tab-help-eyebrow");
     const elTitle = document.getElementById("tab-help-title");
     const elDesc = document.getElementById("tab-help-desc");
     const elTips = document.getElementById("tab-help-tips");
     const elClose = document.getElementById("tab-help-close");
     const elTour = document.getElementById("tab-help-tour");
     let on = false;
+    let scope = "tab"; // "tab" = current tab · "sidebar" = right panel ("?" button)
+
+    // One-time: a "replay walkthrough" link at the top of the panel foot.
+    const foot = document.getElementById("tab-help-foot");
+    let elWalk = document.getElementById("tab-help-walk");
+    if (foot && !elWalk) {
+      elWalk = document.createElement("a");
+      elWalk.href = "#";
+      elWalk.id = "tab-help-walk";
+      elWalk.innerHTML = '<i class="fas fa-play"></i> Walk me through this view';
+      foot.insertBefore(elWalk, foot.firstChild);
+    }
 
     function currentTab() {
       const active = document.querySelector(".tab-btn.active");
@@ -497,7 +947,32 @@
     function stepFor(tab) {
       return STEPS.find((s) => s.tab === tab) || null;
     }
+    // Steps for the stepped Spotlight walkthrough (current scope).
+    function walkStepsFor() {
+      if (scope === "sidebar") return SIDEBAR_STEPS;
+      const tab = currentTab();
+      if (TAB_AREAS[tab]) return TAB_AREAS[tab];
+      const s = stepFor(tab);
+      return s ? [{ sel: "#pane-" + tab, icon: s.icon, title: s.title, desc: s.desc, tips: s.tips }] : [];
+    }
     function renderPanel() {
+      if (scope === "sidebar") {
+        if (elEyebrow) elEyebrow.innerHTML = '<i class="fas fa-circle-info"></i> Right panel';
+        elGroup.textContent = "Filters & sample colours";
+        elFig.innerHTML = FIG.sidebar || "";
+        elTitle.textContent = "The right panel";
+        elDesc.textContent =
+          "Filters, search, the confidence cutoff and sample colours all live here and apply across every tab at once.";
+        elTips.innerHTML = [
+          "Search by sample or organism (regex supported).",
+          "A sample's colour swatch sets its colour everywhere.",
+          "Export Report PDF captures the current filtered state.",
+        ]
+          .map((t) => `<li>${t}</li>`)
+          .join("");
+        return;
+      }
+      if (elEyebrow) elEyebrow.innerHTML = '<i class="fas fa-circle-info"></i> Help mode';
       const tab = currentTab();
       const step = stepFor(tab);
       const info = (typeof PDF_SECTION_INFO !== "undefined" && PDF_SECTION_INFO[tab]) || {};
@@ -514,23 +989,56 @@
       elDesc.textContent = step.desc || "";
       elTips.innerHTML = (step.tips || []).map((t) => `<li>${t}</li>`).join("");
     }
-    function setOn(v) {
+    function startWalk() {
+      const steps = walkStepsFor();
+      if (steps && steps.length) Spotlight.start(steps, {});
+    }
+    function syncButtons() {
+      btn.classList.toggle("on", on && scope === "tab");
+      btn.setAttribute("aria-pressed", on && scope === "tab" ? "true" : "false");
+      if (sideBtn) {
+        sideBtn.classList.toggle("on", on && scope === "sidebar");
+        sideBtn.setAttribute("aria-pressed", on && scope === "sidebar" ? "true" : "false");
+      }
+    }
+    function setOn(v, nextScope) {
       on = v;
-      btn.classList.toggle("on", on);
-      btn.setAttribute("aria-pressed", on ? "true" : "false");
+      scope = v && nextScope ? nextScope : v ? scope : "tab";
+      syncButtons();
       panel.classList.toggle("open", on);
       panel.setAttribute("aria-hidden", on ? "false" : "true");
-      if (on) renderPanel();
+      if (on) {
+        renderPanel();
+        startWalk();
+      } else {
+        Spotlight.stop();
+      }
     }
-    btn.addEventListener("click", () => setOn(!on));
+    btn.addEventListener("click", () => setOn(!(on && scope === "tab"), "tab"));
+    if (sideBtn) sideBtn.addEventListener("click", () => setOn(!(on && scope === "sidebar"), "sidebar"));
     elClose.addEventListener("click", () => setOn(false));
+    if (elWalk)
+      elWalk.addEventListener("click", (e) => {
+        e.preventDefault();
+        startWalk();
+      });
     elTour.addEventListener("click", (e) => {
       e.preventDefault();
       setOn(false);
       open();
     });
-    // Re-render when the user switches tabs while help mode is on.
+    // While help mode is on, follow tab switches: snap back to tab scope,
+    // re-render the panel and restart the walkthrough for the new tab.
     const tabbar = document.getElementById("tabbar");
-    if (tabbar) tabbar.addEventListener("click", () => on && setTimeout(renderPanel, 60));
+    if (tabbar)
+      tabbar.addEventListener("click", () => {
+        if (!on) return;
+        scope = "tab";
+        syncButtons();
+        setTimeout(() => {
+          renderPanel();
+          startWalk();
+        }, 90);
+      });
   })();
 })();

--- a/assets/src/js/37_specimen_merge.js
+++ b/assets/src/js/37_specimen_merge.js
@@ -261,15 +261,28 @@
       header.addEventListener("dragover", (e) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = "move";
+        // Give visual + positional feedback on which side of this header the
+        // dragged group will land — dropping on the lower half moves it
+        // *below* this specimen (needed to drag a group all the way down,
+        // e.g. past the last group), the upper half moves it above.
+        const after = _dropIsAfter(e, header);
         header.style.outline = "2px solid #fff";
+        header.style.borderTop = after ? "" : "3px solid #fff";
+        header.style.borderBottom = after ? "3px solid #fff" : "none";
       });
-      header.addEventListener("dragleave", () => (header.style.outline = ""));
+      header.addEventListener("dragleave", () => {
+        header.style.outline = "";
+        header.style.borderTop = "";
+        header.style.borderBottom = "none";
+      });
       header.addEventListener("drop", (e) => {
         e.preventDefault();
         header.style.outline = "";
+        header.style.borderTop = "";
+        header.style.borderBottom = "none";
         const draggedSpec = e.dataTransfer.getData("application/x-specimen-group");
         if (!draggedSpec || draggedSpec === spec) return;
-        _reorderSpecimenGroup(draggedSpec, spec, groups);
+        _reorderSpecimenGroup(draggedSpec, spec, groups, _dropIsAfter(e, header));
       });
 
       i = j;
@@ -283,17 +296,36 @@
         if (!e.dataTransfer.types.includes("application/x-specimen-group")) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = "move";
+        const after = _dropIsAfter(e, row);
+        row.style.borderTop = after ? "" : "3px solid #1565c0";
+        row.style.borderBottom = after ? "3px solid #1565c0" : "";
+      });
+      row.addEventListener("dragleave", () => {
+        row.style.borderTop = "";
+        row.style.borderBottom = "";
       });
       row.addEventListener("drop", (e) => {
         const draggedSpec = e.dataTransfer.getData("application/x-specimen-group");
         if (!draggedSpec) return;
         e.preventDefault();
         e.stopImmediatePropagation();
+        row.style.borderTop = "";
+        row.style.borderBottom = "";
+        const after = _dropIsAfter(e, row);
         const targetSample = row.getAttribute("data-sid");
         const targetSpec = typeof specimenOf === "function" ? specimenOf(targetSample) : targetSample;
-        if (draggedSpec !== targetSpec) _reorderSpecimenGroup(draggedSpec, targetSpec, groups);
+        if (draggedSpec !== targetSpec) _reorderSpecimenGroup(draggedSpec, targetSpec, groups, after);
       });
     });
+  }
+
+  // True when the drag event's pointer sits in the lower half of `el` — used
+  // to decide whether a dropped specimen group should land above or below
+  // the row/header it was dropped on, so a group can be dragged to *any*
+  // position (including all the way to the bottom, past the last group).
+  function _dropIsAfter(e, el) {
+    const rect = el.getBoundingClientRect();
+    return e.clientY - rect.top > rect.height / 2;
   }
 
   function _coalesceSpecimenOrder() {
@@ -308,16 +340,31 @@
   }
 
   // Move every sample belonging to `draggedSpec` to sit immediately before
-  // the first sample of `targetSpec` in the global sample display order,
-  // then rebuild the sidebar so the DOM (and every downstream view that
-  // reads _sampleOrder) reflects the new grouping.
-  function _reorderSpecimenGroup(draggedSpec, targetSpec, groups) {
+  // (or, when `after` is true, immediately after) `targetSpec`'s samples in
+  // the global sample display order, then rebuild the sidebar so the DOM
+  // (and every downstream view that reads _sampleOrder) reflects the new
+  // grouping. Honoring `after` matters: without it, a drop always inserted
+  // *before* the target, so a group could never be moved past the last
+  // specimen in the list — dragging "down" beyond the last group looked like
+  // a no-op.
+  function _reorderSpecimenGroup(draggedSpec, targetSpec, groups, after) {
     if (typeof _sampleOrder === "undefined") return;
     const draggedMembers = (groups.get(draggedSpec) || []).filter((s) => _sampleOrder.includes(s));
     if (!draggedMembers.length) return;
     const rest = _sampleOrder.filter((s) => !draggedMembers.includes(s));
-    const anchorIdx = rest.findIndex((s) => (typeof specimenOf === "function" ? specimenOf(s) : s) === targetSpec);
-    const insertAt = anchorIdx === -1 ? rest.length : anchorIdx;
+    const isTarget = (s) => (typeof specimenOf === "function" ? specimenOf(s) : s) === targetSpec;
+    let insertAt;
+    if (after) {
+      // Last index belonging to targetSpec, insert right after it.
+      let lastIdx = -1;
+      rest.forEach((s, i) => {
+        if (isTarget(s)) lastIdx = i;
+      });
+      insertAt = lastIdx === -1 ? rest.length : lastIdx + 1;
+    } else {
+      const anchorIdx = rest.findIndex(isTarget);
+      insertAt = anchorIdx === -1 ? rest.length : anchorIdx;
+    }
     rest.splice(insertAt, 0, ...draggedMembers);
     _sampleOrder = rest;
     if (typeof buildSampleList === "function") buildSampleList();

--- a/assets/src/js/37_specimen_merge.js
+++ b/assets/src/js/37_specimen_merge.js
@@ -1,0 +1,964 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+       -  §  SPECIMEN MERGE  (right-panel control + drag-to-group modal)
+       -     Lets an analyst treat several samples (e.g. a DNA and an RNA
+       -     library from one swab) as a single biological specimen. Grouping
+       -     defaults to the samplesheet `specimen` column (via SAMPLE_META →
+       -     specimenOf) and can be edited live by dragging samples together.
+       -
+       -     • Right-panel bar  — a Merge On/Off toggle + a "Group…" button.
+       -     • Group modal      — drag sample chips into specimen bins, name a
+       -                          new specimen when you drop onto "+ New".
+       -     • Aggregation      — reversible & view-level: filteredData()
+       -                          collapses rows per specimen (reads summed,
+       -                          TASS/coverage taken as the max). Nothing in
+       -                          the underlying DATA array is mutated, so the
+       -                          toggle restores per-sample rows instantly.
+       -     • Metadata guard   — before applying, conflicting per-sample
+       -                          metadata (lat/long, run, collection time, …)
+       -                          is surfaced and the user picks which value
+       -                          the merged specimen should keep.
+═══════════════════════════════════════════════════════════════════════════ */
+(function () {
+  "use strict";
+
+  // Pipeline bookkeeping is not biological/run metadata and should never
+  // trigger a merge warning. Every other populated RUN_META field is checked
+  // dynamically, so schema-added fields get the same protection automatically.
+  const _META_SKIP = new Set([
+    "sample_name",
+    "sample_type",
+    "workflow_revision",
+    "commit_id",
+    "total_reads",
+    "aligned_reads",
+    "total_organism_reads",
+    "num_species_groups",
+    "num_keys",
+    "num_subkeys",
+    "num_toplevelkeys",
+    "weights",
+    "best_cutoffs",
+    "best_cutoffs_source",
+    "best_cutoffs_by_domain",
+    "preferred_granularity",
+  ]);
+  const _META_FIRST = [
+    "latitude",
+    "longitude",
+    "sample_origin_country",
+    "sample_origin_state_province_territory",
+    "location",
+    "host_scientific_name",
+    "host_disease",
+    "environmental_site",
+    "collection_time",
+    "run_id",
+    "platform",
+    "depth",
+    "salinity",
+  ];
+
+  /* ── data helpers ──────────────────────────────────────────────────── */
+
+  // Every known sample id (union of SAMPLE_META, DATA and RUN_META).
+  function _samples() {
+    const s = new Set();
+    if (typeof SAMPLE_META !== "undefined") Object.keys(SAMPLE_META || {}).forEach((k) => s.add(k));
+    if (typeof DATA !== "undefined") DATA.forEach((r) => r["Specimen ID"] && s.add(r["Specimen ID"]));
+    if (typeof RUN_META !== "undefined") RUN_META.forEach((r) => r.sample_name && s.add(r.sample_name));
+    return Array.from(s).filter(Boolean);
+  }
+
+  // Merge whatever metadata we have for a sample from SAMPLE_META + RUN_META.
+  function _metaFor(sample) {
+    const sm = (typeof SAMPLE_META !== "undefined" && SAMPLE_META[sample]) || {};
+    const rm = (typeof RUN_META !== "undefined" && RUN_META.find((r) => r.sample_name === sample)) || {};
+    return Object.assign({}, sm, rm);
+  }
+
+  const _norm = (v) => (v == null ? "" : String(v).trim());
+  const _metaLabel = (field) =>
+    typeof _metaKeyLabel === "function"
+      ? _metaKeyLabel(field)
+      : field.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  const _isMultiMeta = (field) =>
+    typeof _MULTI_VALUE_META_FIELDS !== "undefined" && _MULTI_VALUE_META_FIELDS.includes(field);
+  const _metaValues = (v, multi) => {
+    if (v == null || v === "") return [];
+    const vals = Array.isArray(v) ? v : multi && typeof _splitMultiMetaValue === "function" ? _splitMultiMetaValue(v) : [v];
+    return (Array.isArray(vals) ? vals : [vals]).map((x) => String(x).trim()).filter(Boolean);
+  };
+
+  // A sample's molecule type, derived from its DATA rows: "dna" or "rna" when
+  // unambiguous, "" when the sample mixes both, carries neither, or is unknown
+  // (rendered as a white/empty indicator).
+  function _sampleMolType(sample) {
+    if (typeof DATA === "undefined") return "";
+    const seen = new Set();
+    for (let i = 0; i < DATA.length; i++) {
+      if (DATA[i]["Specimen ID"] !== sample) continue;
+      const mt = (DATA[i]["Mol Type"] || "").toLowerCase();
+      if (mt === "dna" || mt === "rna") seen.add(mt);
+    }
+    return seen.size === 1 ? Array.from(seen)[0] : "";
+  }
+  // Colours for the mol-type dot on a chip. Both / none / unknown → white.
+  const _MOLTYPE_DOT = { dna: "#1565c0", rna: "#e8590c" };
+  function _molDotStyle(sample) {
+    const mt = _sampleMolType(sample);
+    const bg = _MOLTYPE_DOT[mt] || "#fff";
+    const title = mt ? mt.toUpperCase() : "DNA + RNA / unspecified";
+    return { bg, title, mt };
+  }
+
+  // Ensure specimen colours exist, then group the right-panel sample rows
+  // under a draggable background-box header per specimen — instead of
+  // appending a per-row name chip that had no width limit and could shove
+  // the sample name off to the right. The header + its member rows read as
+  // one enveloped box; dragging the header (its grip) moves every member of
+  // that specimen together to a new position, resorting the whole group in
+  // one drag instead of dragging each sample individually.
+  function _annotateSidebar() {
+    const cont = document.getElementById("sample-list");
+    if (!cont) return;
+    if (typeof _ensureSpecimenColors === "function") _ensureSpecimenColors();
+
+    // buildSampleList() rebuilds every row on each call and always re-runs
+    // this afterward, so start from a clean slate every time.
+    cont.querySelectorAll(".specimen-group-header").forEach((h) => h.remove());
+    cont.querySelectorAll(".sample-entry[data-sid]").forEach((row) => {
+      row.style.background = "";
+      row.style.borderLeft = "";
+      row.style.borderRadius = "";
+      row.style.paddingLeft = "";
+    });
+
+    const on = typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled;
+    if (!on) return;
+    const groups = typeof specimenGroups === "function" ? specimenGroups() : new Map();
+
+    // A merged specimen is one sortable unit. Keep all of its member rows
+    // contiguous in both the shared order and the DOM, preserving the order in
+    // which specimen groups first appear and the member order within each one.
+    _coalesceSpecimenOrder();
+    const rowsById = new Map(
+      Array.from(cont.querySelectorAll(".sample-entry[data-sid]")).map((row) => [row.getAttribute("data-sid"), row]),
+    );
+    _sampleOrder.forEach((s) => {
+      const row = rowsById.get(s);
+      if (row) cont.appendChild(row);
+    });
+
+    // Walk rows in current DOM order; wherever a run of consecutive rows
+    // shares a multi-member specimen, insert one header above the run and
+    // tint the run so it reads as an enveloping box beneath it.
+    const rows = Array.from(cont.querySelectorAll(".sample-entry[data-sid]"));
+    let i = 0;
+    while (i < rows.length) {
+      const sid = rows[i].getAttribute("data-sid");
+      const spec = typeof specimenOf === "function" ? specimenOf(sid) : sid;
+      const grp = groups.get(spec);
+      if (!spec || spec === sid || !grp || grp.length <= 1) {
+        i++;
+        continue;
+      }
+      const run = [rows[i]];
+      let j = i + 1;
+      while (j < rows.length && (typeof specimenOf === "function" ? specimenOf(rows[j].getAttribute("data-sid")) : "") === spec) {
+        run.push(rows[j]);
+        j++;
+      }
+      const col = (typeof sampleColors !== "undefined" && sampleColors[spec]) || "#1565c0";
+
+      const header = document.createElement("div");
+      header.className = "specimen-group-header";
+      header.dataset.spec = spec;
+      header.draggable = true;
+      header.title = "Drag to reorder this specimen group";
+      header.style.cssText =
+        "display:flex;align-items:center;gap:5px;font-size:0.68em;font-weight:700;color:#fff;" +
+        "padding:2px 6px;margin-top:4px;border-radius:4px 4px 0 0;background:" +
+        col +
+        ";cursor:grab;";
+      header.innerHTML =
+        `<i class="fas fa-grip-vertical" style="opacity:0.75;flex-shrink:0;"></i>` +
+        `<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0;" title="Merged specimen: ${_esc(
+          spec,
+        )}">${_esc(spec)}</span>` +
+        `<span style="opacity:0.85;flex-shrink:0;" title="${run.length} shown on this page">${grp.length} sample${
+          grp.length > 1 ? "s" : ""
+        }</span>`;
+      cont.insertBefore(header, run[0]);
+
+      // The envelope: a tint + left border across the whole run, sized to
+      // its own content (no fixed width to overflow).
+      run.forEach((row, idx) => {
+        row.style.background = col + "14";
+        row.style.borderLeft = "3px solid " + col;
+        row.style.paddingLeft = "3px";
+        row.style.borderRadius = idx === run.length - 1 ? "0 0 4px 4px" : "0";
+      });
+
+      header.addEventListener("dragstart", (e) => {
+        e.dataTransfer.effectAllowed = "move";
+        e.dataTransfer.setData("application/x-specimen-group", spec);
+        header.style.opacity = "0.5";
+      });
+      header.addEventListener("dragend", () => (header.style.opacity = ""));
+      header.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        header.style.outline = "2px solid #fff";
+      });
+      header.addEventListener("dragleave", () => (header.style.outline = ""));
+      header.addEventListener("drop", (e) => {
+        e.preventDefault();
+        header.style.outline = "";
+        const draggedSpec = e.dataTransfer.getData("application/x-specimen-group");
+        if (!draggedSpec || draggedSpec === spec) return;
+        _reorderSpecimenGroup(draggedSpec, spec, groups);
+      });
+
+      i = j;
+    }
+
+    // A merged header must also be droppable onto a singleton row; previously
+    // groups could only be sorted relative to other merged headers, which made
+    // sorting appear broken in runs containing singleton specimens.
+    cont.querySelectorAll(".sample-entry[data-sid]").forEach((row) => {
+      row.addEventListener("dragover", (e) => {
+        if (!e.dataTransfer.types.includes("application/x-specimen-group")) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+      });
+      row.addEventListener("drop", (e) => {
+        const draggedSpec = e.dataTransfer.getData("application/x-specimen-group");
+        if (!draggedSpec) return;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        const targetSample = row.getAttribute("data-sid");
+        const targetSpec = typeof specimenOf === "function" ? specimenOf(targetSample) : targetSample;
+        if (draggedSpec !== targetSpec) _reorderSpecimenGroup(draggedSpec, targetSpec, groups);
+      });
+    });
+  }
+
+  function _coalesceSpecimenOrder() {
+    if (typeof _sampleOrder === "undefined" || typeof specimenOf !== "function") return;
+    const bySpec = new Map();
+    _sampleOrder.forEach((s) => {
+      const spec = specimenOf(s);
+      if (!bySpec.has(spec)) bySpec.set(spec, []);
+      bySpec.get(spec).push(s);
+    });
+    _sampleOrder = Array.from(bySpec.values()).flat();
+  }
+
+  // Move every sample belonging to `draggedSpec` to sit immediately before
+  // the first sample of `targetSpec` in the global sample display order,
+  // then rebuild the sidebar so the DOM (and every downstream view that
+  // reads _sampleOrder) reflects the new grouping.
+  function _reorderSpecimenGroup(draggedSpec, targetSpec, groups) {
+    if (typeof _sampleOrder === "undefined") return;
+    const draggedMembers = (groups.get(draggedSpec) || []).filter((s) => _sampleOrder.includes(s));
+    if (!draggedMembers.length) return;
+    const rest = _sampleOrder.filter((s) => !draggedMembers.includes(s));
+    const anchorIdx = rest.findIndex((s) => (typeof specimenOf === "function" ? specimenOf(s) : s) === targetSpec);
+    const insertAt = anchorIdx === -1 ? rest.length : anchorIdx;
+    rest.splice(insertAt, 0, ...draggedMembers);
+    _sampleOrder = rest;
+    if (typeof buildSampleList === "function") buildSampleList();
+    if (typeof redraw === "function") redraw();
+  }
+
+  /* ── right-panel bar ───────────────────────────────────────────────── */
+
+  function refreshBar() {
+    const bar = document.getElementById("specimen-merge-bar");
+    if (!bar) return;
+    const samples = _samples();
+    // Show the bar whenever there is more than one sample to combine.
+    bar.style.display = samples.length > 1 ? "flex" : "none";
+
+    const grouped = typeof hasSpecimenGrouping === "function" && hasSpecimenGrouping();
+    const tog = document.getElementById("specimen-merge-toggle");
+    if (tog) {
+      const on = typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled;
+      tog.textContent = "Merge: " + (on ? "On" : "Off");
+      tog.style.background = on ? "#1565c0" : "#fff";
+      tog.style.color = on ? "#fff" : "#1565c0";
+      tog.style.opacity = grouped ? "1" : "0.75";
+      // Hover explanation is provided by the richer showTip tooltip wired in
+      // wire() (_mergeToggleTip); no native title attribute needed here.
+    }
+
+    const cnt = document.getElementById("specimen-merge-count");
+    if (cnt) {
+      const groups = typeof specimenGroups === "function" ? specimenGroups() : new Map();
+      const nSpec = groups.size;
+      const nMerged = Array.from(groups.values()).filter((m) => m.length > 1).length;
+      cnt.textContent = nMerged ? `${nSpec} specimen(s), ${nMerged} merged` : `${samples.length} sample(s)`;
+    }
+    if (typeof _ensureSpecimenColors === "function") _ensureSpecimenColors();
+    _annotateSidebar();
+  }
+
+  function setEnabled(on) {
+    if (typeof specimenMergeEnabled === "undefined") return;
+    specimenMergeEnabled = !!on;
+    if (typeof _ensureSpecimenColors === "function") _ensureSpecimenColors();
+    if (typeof _invalidateFilterCache === "function") _invalidateFilterCache();
+    refreshBar();
+    const bannerSub = document.getElementById("banner-sub");
+    if (bannerSub && typeof _buildBannerSub === "function") bannerSub.textContent = _buildBannerSub();
+    if (typeof _rebuildMapMarkers === "function") _rebuildMapMarkers();
+    if (typeof _buildRunMetaTable === "function") _buildRunMetaTable();
+    if (typeof redraw === "function") redraw();
+  }
+
+  /* ── metadata conflict detection ───────────────────────────────────── */
+
+  // For a proposed assignment (sample → specimen), find fields whose value
+  // differs across the members of any multi-sample specimen. Single-valued
+  // fields require one selected value; declared multiselect fields are safely
+  // union-merged and shown as an informational notice.
+  function findConflicts(assign) {
+    const bySpec = new Map();
+    Object.keys(assign).forEach((s) => {
+      const g = assign[s];
+      if (!bySpec.has(g)) bySpec.set(g, []);
+      bySpec.get(g).push(s);
+    });
+    const conflicts = [];
+    bySpec.forEach((members, spec) => {
+      if (members.length < 2) return;
+      const fieldSet = new Set(_META_FIRST);
+      members.forEach((s) => {
+        const rm = (typeof RUN_META !== "undefined" && RUN_META.find((r) => r.sample_name === s)) || {};
+        Object.keys(rm).forEach((field) => {
+          if (!_META_SKIP.has(field)) fieldSet.add(field);
+        });
+      });
+      const fields = Array.from(fieldSet).sort((a, b) => {
+        const ai = _META_FIRST.indexOf(a),
+          bi = _META_FIRST.indexOf(b);
+        if (ai !== -1 || bi !== -1) return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+        return a.localeCompare(b);
+      });
+      fields.forEach((field) => {
+        const multi = _isMultiMeta(field);
+        const seen = new Map(); // value → samples carrying it
+        members.forEach((s) => {
+          _metaValues(_metaFor(s)[field], multi).forEach((v) => {
+            if (!seen.has(v)) seen.set(v, []);
+            seen.get(v).push(s);
+          });
+        });
+        if (multi && seen.size) {
+          conflicts.push({
+            spec,
+            field,
+            label: _metaLabel(field),
+            kind: "multi",
+            merged: Array.from(seen.keys()).sort((a, b) => a.localeCompare(b)),
+            options: Array.from(seen.entries()).map(([value, samples]) => ({ value, samples })),
+          });
+        } else if (seen.size > 1) {
+          conflicts.push({
+            spec,
+            field,
+            label: _metaLabel(field),
+            kind: "single",
+            options: Array.from(seen.entries()).map(([value, samples]) => ({ value, samples })),
+          });
+        }
+      });
+    });
+    return conflicts;
+  }
+
+  /* ── modal plumbing ────────────────────────────────────────────────── */
+
+  function _closeModal() {
+    const m = document.getElementById("specimen-merge-modal");
+    if (m) m.remove();
+  }
+
+  function _esc(s) {
+    return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
+  // Build the initial staged assignment from the live grouping. Samples that
+  // are their own singleton specimen start "unassigned"; anything already in a
+  // multi-sample (or renamed) specimen starts inside that bin.
+  function _initialAssign() {
+    const assign = {};
+    _samples().forEach((s) => {
+      const g = typeof specimenOf === "function" ? specimenOf(s) : s;
+      if (g && g !== s) assign[s] = g;
+    });
+    // Also honour metadata groups where >1 sample share a name even == sample.
+    if (typeof specimenGroups === "function") {
+      specimenGroups().forEach((members, g) => {
+        if (members.length > 1) members.forEach((s) => (assign[s] = g));
+      });
+    }
+    return assign;
+  }
+
+  function openModal(opts) {
+    opts = opts || {};
+    _closeModal();
+    const assign = opts.assign ? Object.assign({}, opts.assign) : _initialAssign(); // staged; committed on Apply
+    // Display order of specimen boxes — user-draggable, preserved across
+    // re-renders; new groups append at the end, removed groups drop out.
+    let _binOrder = [];
+    let _selectedSpec = null;
+
+    const back = document.createElement("div");
+    back.id = "specimen-merge-modal";
+    back.style.cssText =
+      "position:fixed;inset:0;background:rgba(0,0,0,0.45);z-index:10001;display:flex;align-items:center;justify-content:center;";
+
+    back.innerHTML =
+      `<div style="background:#fff;border-radius:8px;max-width:760px;width:94%;height:94vh;max-height:820px;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.3);">` +
+      `<div style="padding:14px 18px;border-bottom:1px solid #eee;display:flex;align-items:center;gap:8px;">` +
+      `<b style="font-size:1.02em;color:#1565c0;"><i class="fas fa-object-group"></i> ${_esc(
+        opts.title || "Group samples into specimens",
+      )}</b>` +
+      `<span style="flex:1"></span>` +
+      `<span style="cursor:pointer;font-size:1.3em;color:#888;" id="sm-close">&times;</span>` +
+      `</div>` +
+      `<div style="padding:6px 18px;font-size:0.82em;color:#666;">${
+        opts.message ||
+        "Drag samples into a specimen to combine them (e.g. a DNA and RNA library from one swab). Reads are summed and the TASS score becomes the strongest across the group. Drop onto <b>+ New specimen</b> to create and name one."
+      }` +
+      `<span style="display:inline-flex;align-items:center;gap:10px;margin-left:6px;">` +
+      `<span style="display:inline-flex;align-items:center;gap:3px;"><span style="width:9px;height:9px;border-radius:50%;background:#1565c0;display:inline-block;"></span>DNA</span>` +
+      `<span style="display:inline-flex;align-items:center;gap:3px;"><span style="width:9px;height:9px;border-radius:50%;background:#e8590c;display:inline-block;"></span>RNA</span>` +
+      `<span style="display:inline-flex;align-items:center;gap:3px;"><span style="width:9px;height:9px;border-radius:50%;background:#fff;border:1px solid #b8c8e0;display:inline-block;"></span>both / unspecified</span>` +
+      `</span></div>` +
+      `<div style="display:flex;align-items:center;gap:7px;padding:0 18px 4px;">` +
+      `<div style="position:relative;flex:1;min-width:0;"><i class="fas fa-magnifying-glass" aria-hidden="true" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:0.72em;color:#90a4ae;"></i>` +
+      `<input id="sm-sample-search" type="search" placeholder="Search samples or specimen groups…" aria-label="Search samples or specimen groups" style="box-sizing:border-box;width:100%;padding:5px 8px 5px 25px;border:1px solid #c5d3e3;border-radius:5px;font-size:0.78em;"></div>` +
+      `<span id="sm-search-count" style="font-size:0.7em;color:#78909c;white-space:nowrap;"></span></div>` +
+      `<div style="display:flex;gap:12px;padding:8px 18px 4px;overflow:auto;flex:1 1 auto;min-height:150px;">` +
+      `<div style="flex:1;min-width:210px;display:flex;flex-direction:column;">` +
+      `<div style="font-size:0.75em;color:#888;font-weight:600;margin-bottom:4px;">Unassigned samples</div>` +
+      `<div id="sm-pool" class="sm-drop" data-bin="" style="flex:1;min-height:120px;border:1px dashed #cbd5e6;border-radius:6px;padding:6px;overflow:auto;background:#fafcff;"></div>` +
+      `</div>` +
+      `<div style="flex:1.2;min-width:240px;display:flex;flex-direction:column;">` +
+      `<div style="font-size:0.75em;color:#888;font-weight:600;margin-bottom:4px;">Specimens <span style="font-weight:400;color:#aab;">(drag a box by its <i class="fas fa-grip-vertical"></i> handle to reorder)</span></div>` +
+      `<div id="sm-bins" style="flex:1;overflow:auto;"></div>` +
+      `<div id="sm-newbin" class="sm-drop" data-bin="__new__" style="margin-top:6px;border:1px dashed #1565c0;border-radius:6px;padding:8px;text-align:center;color:#1565c0;font-size:0.8em;font-weight:600;background:#f0f7ff;cursor:copy;">+ New specimen <span style="color:#88a;">(drop here to create)</span></div>` +
+      `</div>` +
+      `</div>` +
+      `<div id="sm-conflicts" style="padding:0 18px;max-height:28vh;overflow:auto;flex:0 1 auto;"></div>` +
+      `<div style="padding:12px 18px;border-top:1px solid #eee;display:flex;gap:8px;align-items:center;">` +
+      `<button id="sm-reset" style="padding:5px 12px;border:1px solid #ccc;border-radius:5px;background:#fff;color:#666;cursor:pointer;font-size:0.85em;">Reset to samplesheet</button>` +
+      `<span style="flex:1"></span>` +
+      `<button id="sm-cancel" style="padding:5px 12px;border:1px solid #ccc;border-radius:5px;background:#fff;color:#666;cursor:pointer;font-size:0.85em;">Cancel</button>` +
+      `<button id="sm-apply" style="padding:5px 14px;border:1px solid #1565c0;border-radius:5px;background:#1565c0;color:#fff;cursor:pointer;font-size:0.85em;font-weight:600;">Apply &amp; merge</button>` +
+      `</div></div>`;
+
+    document.body.appendChild(back);
+
+    const chip = (s) => {
+      const d = _molDotStyle(s);
+      return (
+        `<span class="sm-chip" draggable="true" data-sample="${_esc(s)}" ` +
+        `style="display:inline-flex;align-items:center;gap:5px;margin:3px;padding:3px 8px;border:1px solid #b8c8e0;` +
+        `border-radius:12px;background:#fff;font-size:0.78em;cursor:grab;">` +
+        `<span title="Mol type: ${d.title}" style="display:inline-block;width:9px;height:9px;border-radius:50%;` +
+        `flex-shrink:0;background:${d.bg};border:1px solid ${d.mt ? d.bg : "#b8c8e0"};"></span>` +
+        `${_esc(s)}</span>`
+      );
+    };
+
+    function render() {
+      const query = String((back.querySelector("#sm-sample-search") || {}).value || "")
+        .trim()
+        .toLowerCase();
+      // Pool = samples with no bin assignment.
+      const allSamples = _samples();
+      const pool = allSamples.filter((s) => !assign[s] && (!query || s.toLowerCase().includes(query)));
+      const poolEl = back.querySelector("#sm-pool");
+      poolEl.innerHTML = pool.length
+        ? pool.map(chip).join("")
+        : `<div style="color:#aab;font-size:0.78em;padding:8px;">${query ? "No matching unassigned samples." : "All samples assigned."}</div>`;
+
+      // Bins = distinct specimen names in assign.
+      const bins = new Map();
+      Object.keys(assign).forEach((s) => {
+        if (!bins.has(assign[s])) bins.set(assign[s], []);
+        bins.get(assign[s]).push(s);
+      });
+
+      // Keep a stable, user-orderable sequence of boxes: preserve whatever
+      // order the user last dragged into, append newly-created groups
+      // (alphabetically) at the end, and drop groups that no longer exist.
+      const liveKeys = Array.from(bins.keys());
+      _binOrder = _binOrder.filter((g) => liveKeys.includes(g));
+      liveKeys
+        .filter((g) => !_binOrder.includes(g))
+        .sort()
+        .forEach((g) => _binOrder.push(g));
+
+      const binsEl = back.querySelector("#sm-bins");
+      if (!bins.size) {
+        binsEl.innerHTML = `<div style="color:#aab;font-size:0.78em;padding:8px;">No specimens yet — drag samples onto “+ New specimen”.</div>`;
+      } else {
+        const renderedBins = _binOrder
+          .map((g) => {
+            const members = bins.get(g).sort();
+            const shownMembers =
+              !query || g.toLowerCase().includes(query)
+                ? members
+                : members.filter((s) => s.toLowerCase().includes(query));
+            if (!shownMembers.length) return "";
+            const multi = members.length > 1;
+            // The whole box is the draggable/droppable unit: a background
+            // envelope around the group name + all its member sample chips,
+            // rather than a standalone name chip that can overflow. Drag the
+            // grip handle to reorder boxes; drop a sample chip anywhere in
+            // the box to assign it to this specimen.
+            return (
+              `<div class="sm-drop sm-bin" draggable="true" data-bin="${_esc(g)}" role="button" tabindex="0" ` +
+              `title="Select this specimen to review its metadata warnings" ` +
+              `style="border:1px solid ${multi ? "#1565c0" : "#d6e2f5"};border-radius:6px;padding:6px 8px;margin-bottom:6px;background:${
+                multi ? "#f0f7ff" : "#fff"
+              };cursor:grab;">` +
+              `<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px;">` +
+              `<i class="fas fa-grip-vertical" style="color:#b0bec5;font-size:0.78em;flex-shrink:0;" title="Drag box to reorder"></i>` +
+              `<b style="font-size:0.8em;color:#0d47a1;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${_esc(
+                g,
+              )}">${_esc(g)}</b>` +
+              `<span style="font-size:0.7em;color:#88a;flex-shrink:0;">${members.length} sample(s)</span>` +
+              `<span style="flex:1"></span>` +
+              `<span class="sm-rename" data-bin="${_esc(g)}" title="Rename specimen" style="cursor:pointer;color:#1565c0;font-size:0.78em;flex-shrink:0;"><i class="fas fa-pen"></i></span>` +
+              `</div>` +
+              `<div>${shownMembers.map(chip).join("")}</div>` +
+              `</div>`
+            );
+          })
+          .join("");
+        binsEl.innerHTML =
+          renderedBins || `<div style="color:#aab;font-size:0.78em;padding:8px;">No matching samples or specimen groups.</div>`;
+      }
+      const matched = query
+        ? allSamples.filter((s) => s.toLowerCase().includes(query) || String(assign[s] || "").toLowerCase().includes(query)).length
+        : allSamples.length;
+      const searchCount = back.querySelector("#sm-search-count");
+      if (searchCount) searchCount.textContent = query ? `${matched} of ${allSamples.length}` : `${allSamples.length} samples`;
+      _wireDnd();
+      // Live conflict preview.
+      _renderConflicts(findConflicts(_multiOnly(assign)));
+    }
+
+    // Assignment restricted to specimens that actually have >1 member.
+    function _multiOnly(a) {
+      const counts = {};
+      Object.values(a).forEach((g) => (counts[g] = (counts[g] || 0) + 1));
+      const out = {};
+      Object.keys(a).forEach((s) => {
+        if (counts[a[s]] > 1) out[s] = a[s];
+      });
+      return out;
+    }
+
+    let _resolved = {}; // spec → { field: value } chosen in the conflict panel
+
+    function _paintSelectedBin() {
+      back.querySelectorAll(".sm-bin").forEach((bin) => {
+        const selected = bin.getAttribute("data-bin") === _selectedSpec;
+        bin.style.boxShadow = selected ? "0 0 0 2px rgba(21,101,192,0.28)" : "";
+        bin.style.borderColor = selected ? "#0d47a1" : "";
+        bin.setAttribute("aria-pressed", selected ? "true" : "false");
+      });
+    }
+
+    function _renderConflicts(conflicts) {
+      const el = back.querySelector("#sm-conflicts");
+      const multiSpecs = Array.from(new Set(Object.values(_multiOnly(assign))));
+      if (!conflicts.length) {
+        el.innerHTML =
+          `<div style="border:1px solid #b7dfc5;background:#f3fbf6;border-radius:6px;padding:7px 10px;margin:4px 0 2px;font-size:0.78em;color:#2b6f44;"><i class="fas fa-circle-check"></i> No differing metadata${
+            _selectedSpec ? ` for <b>${_esc(_selectedSpec)}</b>` : " in the current specimen groups"
+          }.</div>`;
+        _resolved = {};
+        if (_selectedSpec && !multiSpecs.includes(_selectedSpec)) _selectedSpec = null;
+        _paintSelectedBin();
+        return;
+      }
+      const conflictSpecs = Array.from(new Set(conflicts.map((c) => c.spec)));
+      if (!_selectedSpec || !multiSpecs.includes(_selectedSpec)) _selectedSpec = conflictSpecs[0] || multiSpecs[0];
+
+      // Reconcile defaults without discarding choices already made for other
+      // groups. This lets users click through every specimen and retain each
+      // dropdown selection until Apply is pressed.
+      Object.keys(_resolved).forEach((spec) => {
+        if (!conflictSpecs.includes(spec)) delete _resolved[spec];
+      });
+      conflictSpecs.forEach((spec) => {
+        const activeFields = new Set(conflicts.filter((c) => c.spec === spec).map((c) => c.field));
+        Object.keys(_resolved[spec] || {}).forEach((field) => {
+          if (!activeFields.has(field)) delete _resolved[spec][field];
+        });
+      });
+      conflicts.forEach((c) => {
+        _resolved[c.spec] = _resolved[c.spec] || {};
+        const valid = c.kind === "multi" ? c.merged : c.options.map((o) => o.value);
+        const old = _resolved[c.spec][c.field];
+        if (old == null || (c.kind !== "multi" && !valid.includes(old))) {
+          _resolved[c.spec][c.field] = c.kind === "multi" ? c.merged.slice() : c.options[0].value;
+        } else if (c.kind === "multi") {
+          _resolved[c.spec][c.field] = c.merged.slice();
+        }
+      });
+
+      const shown = conflicts.filter((c) => c.spec === _selectedSpec);
+      if (!shown.length) {
+        el.innerHTML =
+          `<div style="border:1px solid #b7dfc5;background:#f3fbf6;border-radius:6px;padding:7px 10px;margin:4px 0 2px;font-size:0.78em;color:#2b6f44;">` +
+          `<i class="fas fa-circle-check"></i> No differing metadata for <b>${_esc(_selectedSpec)}</b>.</div>`;
+        _paintSelectedBin();
+        return;
+      }
+      const singles = shown.filter((c) => c.kind !== "multi");
+      const multis = shown.filter((c) => c.kind === "multi");
+      el.innerHTML =
+        `<div style="border:1px solid #f0c36d;background:#fff9e8;border-radius:6px;padding:8px 10px;margin:4px 0 2px;">` +
+        `<div style="font-size:0.8em;color:#8a6d1a;font-weight:600;margin-bottom:4px;">` +
+        `<i class="fas fa-triangle-exclamation"></i> Metadata warnings for <b>${_esc(_selectedSpec)}</b> ` +
+        `<span style="font-weight:400;color:#9b843f">(${conflictSpecs.indexOf(_selectedSpec) + 1} of ${
+          conflictSpecs.length
+        } group${conflictSpecs.length === 1 ? "" : "s"} with differences)</span></div>` +
+        (singles.length
+          ? `<div style="font-size:0.76em;color:#735c16;margin-bottom:6px;">Choose the one value the merged specimen should keep for each single-value field.</div>`
+          : "") +
+        singles
+          .map((c, i) => {
+            const opts = c.options
+              .map(
+                (o, j) =>
+                  `<option value="${_esc(o.value)}" ${
+                    _resolved[c.spec] && _resolved[c.spec][c.field] === o.value ? "selected" : ""
+                  }>${_esc(o.value)} (${_esc(
+                    o.samples.join(", "),
+                  )})</option>`,
+              )
+              .join("");
+            return (
+              `<label style="display:grid;grid-template-columns:minmax(130px,0.65fr) minmax(180px,1.35fr);gap:8px;align-items:center;margin:4px 0;font-size:0.8em;">` +
+              `<span><b style="color:#8a6d1a;">${_esc(c.spec)}</b> · ${_esc(c.label)}</span>` +
+              `<select class="sm-cf-select" data-spec="${_esc(c.spec)}" data-field="${_esc(
+                c.field,
+              )}" style="min-width:0;width:100%;padding:3px 5px;border:1px solid #d3b25c;border-radius:4px;background:#fff;">${opts}</select></label>`
+            );
+          })
+          .join("") +
+        (multis.length
+          ? `<div style="border-top:${singles.length ? "1px solid #ead9a4" : "0"};margin-top:7px;padding-top:6px;">` +
+            `<div style="font-size:0.78em;color:#2b6f44;font-weight:700;margin-bottom:3px;"><i class="fas fa-code-merge"></i> Multiselect metadata will be merged</div>` +
+            multis
+              .map(
+                (c) =>
+                  `<div style="font-size:0.76em;color:#47634f;margin:3px 0;"><b>${_esc(c.spec)} · ${_esc(
+                    c.label,
+                  )}:</b> ${c.merged.map(_esc).join(", ")}</div>`,
+              )
+              .join("") +
+            `</div>`
+          : "") +
+        `</div>`;
+      _paintSelectedBin();
+      el.querySelectorAll(".sm-cf-select").forEach((select) => {
+        select.addEventListener("change", () => {
+          const spec = select.getAttribute("data-spec");
+          const field = select.getAttribute("data-field");
+          _resolved[spec] = _resolved[spec] || {};
+          _resolved[spec][field] = select.value;
+        });
+      });
+    }
+
+    function _wireDnd() {
+      back.querySelectorAll(".sm-chip").forEach((el) => {
+        el.addEventListener("dragstart", (e) => {
+          e.stopPropagation(); // don't let the enclosing box's dragstart also fire
+          e.dataTransfer.effectAllowed = "move";
+          e.dataTransfer.setData("text/plain", el.getAttribute("data-sample"));
+          el.style.opacity = "0.5";
+        });
+        el.addEventListener("dragend", (e) => {
+          e.stopPropagation();
+          el.style.opacity = "";
+        });
+      });
+      // Whole specimen boxes: dragging the box itself (grip handle or
+      // background, not a sample chip inside it) reorders the boxes.
+      back.querySelectorAll(".sm-bin").forEach((el) => {
+        el.addEventListener("dragstart", (e) => {
+          e.dataTransfer.effectAllowed = "move";
+          e.dataTransfer.setData("application/x-sm-bin", el.getAttribute("data-bin"));
+          el.style.opacity = "0.5";
+        });
+        el.addEventListener("dragend", () => (el.style.opacity = ""));
+        const selectGroup = (e) => {
+          if (e && e.target && e.target.closest(".sm-rename")) return;
+          _selectedSpec = el.getAttribute("data-bin");
+          _renderConflicts(findConflicts(_multiOnly(assign)));
+        };
+        el.addEventListener("click", selectGroup);
+        el.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            selectGroup(e);
+          }
+        });
+      });
+      back.querySelectorAll(".sm-drop").forEach((el) => {
+        el.addEventListener("dragover", (e) => {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "move";
+          el.style.outline = "2px solid #1565c0";
+        });
+        el.addEventListener("dragleave", () => (el.style.outline = ""));
+        el.addEventListener("drop", (e) => {
+          e.preventDefault();
+          el.style.outline = "";
+          const targetBin = el.getAttribute("data-bin");
+
+          // Reordering a specimen box (dropped onto another box).
+          const draggedBin = e.dataTransfer.getData("application/x-sm-bin");
+          if (draggedBin) {
+            if (!targetBin || targetBin === "__new__" || targetBin === draggedBin) return;
+            const from = _binOrder.indexOf(draggedBin);
+            const to = _binOrder.indexOf(targetBin);
+            if (from === -1 || to === -1) return;
+            _binOrder.splice(from, 1);
+            _binOrder.splice(to, 0, draggedBin);
+            render();
+            return;
+          }
+
+          // Assigning a sample chip to a bin (or back to the pool).
+          const sample = e.dataTransfer.getData("text/plain");
+          if (!sample) return;
+          let bin = targetBin;
+          if (bin === "__new__") {
+            const name = (window.prompt("Name for the new specimen:", _suggestName(sample)) || "").trim();
+            if (!name) return;
+            bin = name;
+          }
+          if (bin === "") delete assign[sample]; // back to the pool
+          else assign[sample] = bin;
+          render();
+        });
+      });
+      back.querySelectorAll(".sm-rename").forEach((el) => {
+        el.addEventListener("click", (e) => {
+          e.stopPropagation();
+          const old = el.getAttribute("data-bin");
+          const name = (window.prompt("Rename specimen:", old) || "").trim();
+          if (!name || name === old) return;
+          Object.keys(assign).forEach((s) => {
+            if (assign[s] === old) assign[s] = name;
+          });
+          if (_selectedSpec === old) _selectedSpec = name;
+          render();
+        });
+      });
+    }
+
+    // Suggest a specimen name from a sample id by trimming a trailing
+    // library/mol-type suffix (…-DNA, _RNA, .r1 …) — purely a convenience.
+    function _suggestName(sample) {
+      return String(sample).replace(/([._-])(dna|rna|r[12]|lib\d*|s\d+)$/i, "") || sample;
+    }
+
+    back.addEventListener("click", (e) => {
+      if (e.target === back) _closeModal();
+    });
+    back.querySelector("#sm-close").addEventListener("click", _closeModal);
+    back.querySelector("#sm-cancel").addEventListener("click", _closeModal);
+    back.querySelector("#sm-sample-search").addEventListener("input", render);
+
+    back.querySelector("#sm-reset").addEventListener("click", () => {
+      if (typeof SPECIMEN_OVERRIDE !== "undefined") {
+        Object.keys(SPECIMEN_OVERRIDE).forEach((k) => delete SPECIMEN_OVERRIDE[k]);
+      }
+      if (typeof SPECIMEN_META_RESOLVED !== "undefined") {
+        Object.keys(SPECIMEN_META_RESOLVED).forEach((k) => delete SPECIMEN_META_RESOLVED[k]);
+      }
+      _closeModal();
+      setEnabled(specimenMergeEnabled); // refresh views with defaults restored
+    });
+
+    back.querySelector("#sm-apply").addEventListener("click", () => {
+      // Commit staged assignment → SPECIMEN_OVERRIDE, keeping only genuine
+      // overrides (anything that differs from the samplesheet default).
+      if (typeof SPECIMEN_OVERRIDE !== "undefined") {
+        _samples().forEach((s) => {
+          const meta = _metaFor(s);
+          const metaSp =
+            meta.specimen != null ? meta.specimen : meta.specimen_id != null ? meta.specimen_id : meta.specimen_group;
+          const dflt = _norm(metaSp) || s;
+          const val = assign[s] || s; // unassigned ⇒ its own specimen
+          if (!val || val === dflt) delete SPECIMEN_OVERRIDE[s];
+          else SPECIMEN_OVERRIDE[s] = val;
+        });
+      }
+      // Persist chosen metadata resolutions for merged specimens.
+      if (typeof SPECIMEN_META_RESOLVED !== "undefined") {
+        Object.keys(SPECIMEN_META_RESOLVED).forEach((k) => delete SPECIMEN_META_RESOLVED[k]);
+        Object.keys(_resolved).forEach((spec) => {
+          SPECIMEN_META_RESOLVED[spec] = Object.assign({}, _resolved[spec]);
+        });
+      }
+      _closeModal();
+      setEnabled(true); // show the effect immediately
+      // If the grouping produced no multi-sample specimen, nothing visibly
+      // changes — say so rather than leave the user wondering.
+      const grouped = typeof hasSpecimenGrouping === "function" && hasSpecimenGrouping();
+      if (!grouped) {
+        window.alert("No specimens were merged — drag two or more samples into the same specimen to combine them.");
+      }
+    });
+
+    render();
+  }
+
+  /* ── one-click: combine every sample into a single specimen ─────────── */
+
+  // Assign all known samples to one specimen group and turn merge on — the
+  // fast path for "just treat this whole run as one specimen" without dragging
+  // chips in the modal. Reversible: clears cleanly via Group… → Reset.
+  function combineAll() {
+    const samples = _samples();
+    if (samples.length < 2) return;
+    const dflt = "All samples";
+    const name = (window.prompt("Combine ALL samples into one specimen named:", dflt) || "").trim();
+    if (!name) return;
+    const assign = {};
+    samples.forEach((s) => (assign[s] = name));
+    // Review before committing: single-valued metadata conflicts require an
+    // explicit dropdown choice; multiselect fields show the union that will be
+    // retained. Cancel leaves the current grouping untouched.
+    openModal({
+      assign,
+      title: "Review metadata before combining all samples",
+      message:
+        `<b>Warning:</b> these samples may have different metadata. Review the choices below before merging. ` +
+        `Single-value fields (for example latitude, longitude, country and state/territory) keep one selected value; ` +
+        `multiselect fields (for example host disease) are union-merged.`,
+    });
+  }
+
+  /* ── wiring ────────────────────────────────────────────────────────── */
+
+  // Rich hover explanation of exactly what changes when the toggle flips,
+  // mirroring the aggregation rules applied in _collapseSpecimens().
+  function _mergeToggleTip() {
+    const grouped = typeof hasSpecimenGrouping === "function" && hasSpecimenGrouping();
+    const on = typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled;
+    if (!grouped) {
+      return (
+        `<b style="color:#1565c0">Specimen merge</b><br>` +
+        `<span style="color:#ccc">No specimens grouped yet — click to open <b>Group…</b> and drag samples together first.</span>`
+      );
+    }
+    const action = on
+      ? "Toggling <b>off</b> restores per-sample rows — every sample is shown and scored individually again."
+      : "Toggling <b>on</b> collapses each specimen's samples (e.g. a DNA + RNA library from one swab) into one row.";
+    return (
+      `<b style="color:#1565c0">Specimen merge — ${on ? "On" : "Off"}</b><br>` +
+      `<span style="color:#ccc">${action}</span>` +
+      `<table style="border-collapse:collapse;font-size:0.85em;margin-top:5px">` +
+      `<tr><td style="padding:1px 8px 1px 0;color:#90caf9"># Reads Aligned / Unique Reads / # Reads</td><td style="color:#fff">summed across samples</td></tr>` +
+      `<tr><td style="padding:1px 8px 1px 0;color:#90caf9">TASS, Coverage, Breadth %, evidence scores</td><td style="color:#fff">max across samples</td></tr>` +
+      `<tr><td style="padding:1px 8px 1px 0;color:#90caf9">Mean Depth</td><td style="color:#fff">summed across samples</td></tr>` +
+      `<tr><td style="padding:1px 8px 1px 0;color:#90caf9">Mean MapQ / Mean BaseQ</td><td style="color:#fff">read-weighted mean</td></tr>` +
+      `<tr><td style="padding:1px 8px 1px 0;color:#90caf9">High Consequence / Passes Threshold</td><td style="color:#fff">true if any sample is true</td></tr>` +
+      `<tr><td style="padding:1px 8px 1px 0;color:#90caf9">Mol Type</td><td style="color:#fff">"both" if DNA + RNA mixed</td></tr>` +
+      `<tr><td style="padding:1px 8px 1px 0;color:#90caf9">Everything else</td><td style="color:#fff">taken from the highest-TASS sample</td></tr>` +
+      `</table>` +
+      `<span style="color:#aaa;font-size:0.85em">Nothing in the underlying data is mutated — toggle off any time to see individual samples.</span>`
+    );
+  }
+
+  function wire() {
+    const tog = document.getElementById("specimen-merge-toggle");
+    if (tog && !tog._wired) {
+      tog._wired = true;
+      tog.removeAttribute("title"); // superseded by the richer showTip hover below
+      tog.addEventListener("mouseover", (ev) => {
+        if (typeof showTip === "function") showTip(_mergeToggleTip(), ev);
+      });
+      tog.addEventListener("mousemove", (ev) => {
+        if (typeof moveTip === "function") moveTip(ev);
+      });
+      tog.addEventListener("mouseout", () => {
+        if (typeof hideTip === "function") hideTip();
+      });
+      tog.addEventListener("click", () => {
+        if (typeof hideTip === "function") hideTip();
+        const on = typeof specimenMergeEnabled !== "undefined" && specimenMergeEnabled;
+        // Turning merge ON with nothing grouped yet would be a no-op — send the
+        // user straight to the grouping modal instead of silently doing nothing.
+        if (!on && !(typeof hasSpecimenGrouping === "function" && hasSpecimenGrouping())) {
+          openModal();
+          return;
+        }
+        setEnabled(!on);
+      });
+    }
+    const grp = document.getElementById("specimen-merge-group-btn");
+    if (grp && !grp._wired) {
+      grp._wired = true;
+      grp.addEventListener("click", openModal);
+    }
+    const combineBtn = document.getElementById("specimen-merge-combine-all-btn");
+    if (combineBtn && !combineBtn._wired) {
+      combineBtn._wired = true;
+      combineBtn.addEventListener("click", combineAll);
+    }
+
+    // Default the merge ON when the samplesheet already groups samples into
+    // multi-sample specimens (requirement: merge by the specimen column if
+    // present) — but only once, and never fight a later user toggle.
+    if (!wire._defaulted) {
+      wire._defaulted = true;
+      if (
+        typeof hasSpecimenGrouping === "function" &&
+        hasSpecimenGrouping() &&
+        typeof specimenMergeEnabled !== "undefined" &&
+        !specimenMergeEnabled
+      ) {
+        specimenMergeEnabled = true;
+        if (typeof _invalidateFilterCache === "function") _invalidateFilterCache();
+        if (typeof _rebuildMapMarkers === "function") _rebuildMapMarkers();
+      }
+    }
+
+    // Keep the bar (toggle label + counts) in sync whenever the sample list is
+    // rebuilt (uploads, deletions) by wrapping buildSampleList once.
+    if (typeof buildSampleList === "function" && !buildSampleList._smWrapped) {
+      const orig = buildSampleList;
+      window.buildSampleList = function () {
+        const r = orig.apply(this, arguments);
+        refreshBar();
+        return r;
+      };
+      window.buildSampleList._smWrapped = true;
+    }
+
+    refreshBar();
+  }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", wire);
+  else wire();
+
+  // Expose a few helpers for other modules / debugging.
+  window.specimenMerge = { refreshBar, setEnabled, openModal, combineAll, findConflicts };
+})();

--- a/assets/src/js/37_specimen_merge.js
+++ b/assets/src/js/37_specimen_merge.js
@@ -85,7 +85,11 @@
     typeof _MULTI_VALUE_META_FIELDS !== "undefined" && _MULTI_VALUE_META_FIELDS.includes(field);
   const _metaValues = (v, multi) => {
     if (v == null || v === "") return [];
-    const vals = Array.isArray(v) ? v : multi && typeof _splitMultiMetaValue === "function" ? _splitMultiMetaValue(v) : [v];
+    const vals = Array.isArray(v)
+      ? v
+      : multi && typeof _splitMultiMetaValue === "function"
+      ? _splitMultiMetaValue(v)
+      : [v];
     return (Array.isArray(vals) ? vals : [vals]).map((x) => String(x).trim()).filter(Boolean);
   };
 
@@ -129,6 +133,8 @@
     cont.querySelectorAll(".sample-entry[data-sid]").forEach((row) => {
       row.style.background = "";
       row.style.borderLeft = "";
+      row.style.borderRight = "";
+      row.style.borderBottom = "";
       row.style.borderRadius = "";
       row.style.paddingLeft = "";
     });
@@ -164,7 +170,10 @@
       }
       const run = [rows[i]];
       let j = i + 1;
-      while (j < rows.length && (typeof specimenOf === "function" ? specimenOf(rows[j].getAttribute("data-sid")) : "") === spec) {
+      while (
+        j < rows.length &&
+        (typeof specimenOf === "function" ? specimenOf(rows[j].getAttribute("data-sid")) : "") === spec
+      ) {
         run.push(rows[j]);
         j++;
       }
@@ -177,9 +186,11 @@
       header.title = "Drag to reorder this specimen group";
       header.style.cssText =
         "display:flex;align-items:center;gap:5px;font-size:0.68em;font-weight:700;color:#fff;" +
-        "padding:2px 6px;margin-top:4px;border-radius:4px 4px 0 0;background:" +
+        "padding:2px 6px;margin-top:6px;border-radius:4px 4px 0 0;background:" +
         col +
-        ";cursor:grab;";
+        ";border:2px solid " +
+        col +
+        ";border-bottom:none;box-shadow:0 2px 5px rgba(0,0,0,0.35);position:relative;z-index:1;cursor:grab;";
       header.innerHTML =
         `<i class="fas fa-grip-vertical" style="opacity:0.75;flex-shrink:0;"></i>` +
         `<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0;" title="Merged specimen: ${_esc(
@@ -190,13 +201,55 @@
         }</span>`;
       cont.insertBefore(header, run[0]);
 
-      // The envelope: a tint + left border across the whole run, sized to
-      // its own content (no fixed width to overflow).
+      // Color swatch — same mechanism as an individual sample row's color
+      // picker (an <input type="color"> bound to sampleColors[id]), just
+      // keyed by the specimen name so the whole envelope box can be
+      // recolored right where it's shown, not only from the Group… modal.
+      const colorIn = document.createElement("input");
+      colorIn.type = "color";
+      colorIn.className = "specimen-group-color";
+      colorIn.value = col.length === 7 ? col : "#1565c0"; // input[type=color] needs #rrggbb
+      colorIn.title = `Specimen color: ${spec}`;
+      colorIn.style.cssText =
+        "width:14px;height:14px;padding:0;border:1px solid rgba(255,255,255,0.7);border-radius:3px;flex-shrink:0;cursor:pointer;background:transparent;";
+      colorIn.draggable = false;
+      colorIn.addEventListener("mousedown", (e) => e.stopPropagation());
+      colorIn.addEventListener("click", (e) => e.stopPropagation());
+      colorIn.addEventListener("dragstart", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      });
+      colorIn.addEventListener("input", (e) => {
+        e.stopPropagation();
+        const newCol = e.target.value;
+        if (typeof sampleColors !== "undefined") sampleColors[spec] = newCol;
+        header.style.background = newCol;
+        header.style.border = "2px solid " + newCol;
+        header.style.borderBottom = "none";
+        run.forEach((row, idx) => {
+          const isLast = idx === run.length - 1;
+          row.style.background = newCol + "26";
+          row.style.borderLeft = "4px solid " + newCol;
+          row.style.borderRight = "2px solid " + newCol;
+          row.style.borderBottom = isLast ? "2px solid " + newCol : "none";
+        });
+        if (typeof _refreshMapMarkerColors === "function") _refreshMapMarkerColors();
+        if (typeof redraw === "function") redraw();
+      });
+      header.insertBefore(colorIn, header.firstChild.nextSibling); // after the grip icon
+
+      // The envelope: a stronger tint + full left/right border across the
+      // whole run (not just a left accent), so the box reads as a distinct
+      // enclosure rather than blending into whatever sits above it. The last
+      // row also gets the bottom edge closed off to complete the box.
       run.forEach((row, idx) => {
-        row.style.background = col + "14";
-        row.style.borderLeft = "3px solid " + col;
-        row.style.paddingLeft = "3px";
-        row.style.borderRadius = idx === run.length - 1 ? "0 0 4px 4px" : "0";
+        const isLast = idx === run.length - 1;
+        row.style.background = col + "26"; // ~15% tint — up from ~8%
+        row.style.borderLeft = "4px solid " + col;
+        row.style.borderRight = "2px solid " + col;
+        row.style.borderBottom = isLast ? "2px solid " + col : "none";
+        row.style.paddingLeft = "2px";
+        row.style.borderRadius = isLast ? "0 0 4px 4px" : "0";
       });
 
       header.addEventListener("dragstart", (e) => {
@@ -485,7 +538,9 @@
       const poolEl = back.querySelector("#sm-pool");
       poolEl.innerHTML = pool.length
         ? pool.map(chip).join("")
-        : `<div style="color:#aab;font-size:0.78em;padding:8px;">${query ? "No matching unassigned samples." : "All samples assigned."}</div>`;
+        : `<div style="color:#aab;font-size:0.78em;padding:8px;">${
+            query ? "No matching unassigned samples." : "All samples assigned."
+          }</div>`;
 
       // Bins = distinct specimen names in assign.
       const bins = new Map();
@@ -522,20 +577,37 @@
             // rather than a standalone name chip that can overflow. Drag the
             // grip handle to reorder boxes; drop a sample chip anywhere in
             // the box to assign it to this specimen.
+            // Give the box a color the same way an individual sample row does —
+            // a native <input type="color"> bound to sampleColors[g], so the
+            // merged specimen can be recolored the same way as any sample.
+            if (typeof sampleColors !== "undefined" && !sampleColors[g]) {
+              sampleColors[g] =
+                (sampleColors[members[0]] && sampleColors[members[0]]) ||
+                (typeof PALETTE !== "undefined" && PALETTE.length
+                  ? PALETTE[_binOrder.indexOf(g) % PALETTE.length]
+                  : "#607d8b");
+            }
+            const binColor = (typeof sampleColors !== "undefined" && sampleColors[g]) || "#607d8b";
             return (
               `<div class="sm-drop sm-bin" draggable="true" data-bin="${_esc(g)}" role="button" tabindex="0" ` +
               `title="Select this specimen to review its metadata warnings" ` +
-              `style="border:1px solid ${multi ? "#1565c0" : "#d6e2f5"};border-radius:6px;padding:6px 8px;margin-bottom:6px;background:${
+              `style="border:1px solid ${
+                multi ? "#1565c0" : "#d6e2f5"
+              };border-radius:6px;padding:6px 8px;margin-bottom:6px;background:${
                 multi ? "#f0f7ff" : "#fff"
               };cursor:grab;">` +
               `<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px;">` +
               `<i class="fas fa-grip-vertical" style="color:#b0bec5;font-size:0.78em;flex-shrink:0;" title="Drag box to reorder"></i>` +
+              `<input type="color" class="sm-bin-color" data-bin="${_esc(g)}" value="${_esc(binColor)}" ` +
+              `title="Specimen color" style="width:16px;height:16px;padding:0;border:1px solid #b8c8e0;border-radius:3px;flex-shrink:0;cursor:pointer;">` +
               `<b style="font-size:0.8em;color:#0d47a1;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${_esc(
                 g,
               )}">${_esc(g)}</b>` +
               `<span style="font-size:0.7em;color:#88a;flex-shrink:0;">${members.length} sample(s)</span>` +
               `<span style="flex:1"></span>` +
-              `<span class="sm-rename" data-bin="${_esc(g)}" title="Rename specimen" style="cursor:pointer;color:#1565c0;font-size:0.78em;flex-shrink:0;"><i class="fas fa-pen"></i></span>` +
+              `<span class="sm-rename" data-bin="${_esc(
+                g,
+              )}" title="Rename specimen" style="cursor:pointer;color:#1565c0;font-size:0.78em;flex-shrink:0;"><i class="fas fa-pen"></i></span>` +
               `</div>` +
               `<div>${shownMembers.map(chip).join("")}</div>` +
               `</div>`
@@ -543,13 +615,21 @@
           })
           .join("");
         binsEl.innerHTML =
-          renderedBins || `<div style="color:#aab;font-size:0.78em;padding:8px;">No matching samples or specimen groups.</div>`;
+          renderedBins ||
+          `<div style="color:#aab;font-size:0.78em;padding:8px;">No matching samples or specimen groups.</div>`;
       }
       const matched = query
-        ? allSamples.filter((s) => s.toLowerCase().includes(query) || String(assign[s] || "").toLowerCase().includes(query)).length
+        ? allSamples.filter(
+            (s) =>
+              s.toLowerCase().includes(query) ||
+              String(assign[s] || "")
+                .toLowerCase()
+                .includes(query),
+          ).length
         : allSamples.length;
       const searchCount = back.querySelector("#sm-search-count");
-      if (searchCount) searchCount.textContent = query ? `${matched} of ${allSamples.length}` : `${allSamples.length} samples`;
+      if (searchCount)
+        searchCount.textContent = query ? `${matched} of ${allSamples.length}` : `${allSamples.length} samples`;
       _wireDnd();
       // Live conflict preview.
       _renderConflicts(findConflicts(_multiOnly(assign)));
@@ -581,10 +661,9 @@
       const el = back.querySelector("#sm-conflicts");
       const multiSpecs = Array.from(new Set(Object.values(_multiOnly(assign))));
       if (!conflicts.length) {
-        el.innerHTML =
-          `<div style="border:1px solid #b7dfc5;background:#f3fbf6;border-radius:6px;padding:7px 10px;margin:4px 0 2px;font-size:0.78em;color:#2b6f44;"><i class="fas fa-circle-check"></i> No differing metadata${
-            _selectedSpec ? ` for <b>${_esc(_selectedSpec)}</b>` : " in the current specimen groups"
-          }.</div>`;
+        el.innerHTML = `<div style="border:1px solid #b7dfc5;background:#f3fbf6;border-radius:6px;padding:7px 10px;margin:4px 0 2px;font-size:0.78em;color:#2b6f44;"><i class="fas fa-circle-check"></i> No differing metadata${
+          _selectedSpec ? ` for <b>${_esc(_selectedSpec)}</b>` : " in the current specimen groups"
+        }.</div>`;
         _resolved = {};
         if (_selectedSpec && !multiSpecs.includes(_selectedSpec)) _selectedSpec = null;
         _paintSelectedBin();
@@ -643,9 +722,7 @@
                 (o, j) =>
                   `<option value="${_esc(o.value)}" ${
                     _resolved[c.spec] && _resolved[c.spec][c.field] === o.value ? "selected" : ""
-                  }>${_esc(o.value)} (${_esc(
-                    o.samples.join(", "),
-                  )})</option>`,
+                  }>${_esc(o.value)} (${_esc(o.samples.join(", "))})</option>`,
               )
               .join("");
             return (
@@ -705,7 +782,7 @@
         });
         el.addEventListener("dragend", () => (el.style.opacity = ""));
         const selectGroup = (e) => {
-          if (e && e.target && e.target.closest(".sm-rename")) return;
+          if (e && e.target && e.target.closest(".sm-rename, .sm-bin-color")) return;
           _selectedSpec = el.getAttribute("data-bin");
           _renderConflicts(findConflicts(_multiOnly(assign)));
         };
@@ -767,6 +844,25 @@
           });
           if (_selectedSpec === old) _selectedSpec = name;
           render();
+        });
+      });
+      // Specimen color swatch — same mechanism as the individual sample color
+      // picker in the right-panel sidebar (an <input type="color"> bound to
+      // sampleColors[id]), just keyed by the specimen name instead of a raw
+      // sample id. Takes effect immediately across the report, same as
+      // recoloring a sample.
+      back.querySelectorAll(".sm-bin-color").forEach((el) => {
+        // Prevent the box's own draggable/click handlers from hijacking the
+        // native color-picker interaction.
+        el.addEventListener("mousedown", (e) => e.stopPropagation());
+        el.addEventListener("click", (e) => e.stopPropagation());
+        el.addEventListener("dragstart", (e) => e.preventDefault());
+        el.addEventListener("input", (e) => {
+          e.stopPropagation();
+          const g = el.getAttribute("data-bin");
+          if (typeof sampleColors !== "undefined") sampleColors[g] = e.target.value;
+          if (typeof _refreshMapMarkerColors === "function") _refreshMapMarkerColors();
+          if (typeof redraw === "function") redraw();
         });
       });
     }

--- a/bin/match_paths.py
+++ b/bin/match_paths.py
@@ -3260,6 +3260,40 @@ def main():
             _pcts.append(round(_pct, 1))
         return _pcts
 
+    def _merge_covered_intervals(regs):
+        """Merge a strain's covered_regions into a compact, non-overlapping list
+        of [start, end) runs in the concatenated per-strain coordinate space,
+        returned flat as [s0, e0, s1, e1, ...].
+
+        This is the minimal positional information the report needs to compute an
+        EXACT breadth union across the samples of a merged specimen: two samples'
+        runs can be OR-ed together and re-binned, so coverage that lands in the
+        gaps of another sample is counted (per-bin max would drop it). Flat form
+        keeps the JSON small; runs are already sparse for real genomes.
+        """
+        _iv = sorted((int(_s), int(_e)) for (_s, _e, _d) in regs if int(_e) > int(_s))
+        if not _iv:
+            return []
+        _merged = []
+        _cs, _ce = _iv[0]
+        for _s, _e in _iv[1:]:
+            if _s <= _ce:
+                if _e > _ce:
+                    _ce = _e
+            else:
+                _merged.append(_cs); _merged.append(_ce)
+                _cs, _ce = _s, _e
+        _merged.append(_cs); _merged.append(_ce)
+        return _merged
+
+    # Cap on flattened interval count per strain (2 numbers per run). Beyond this
+    # the run list would bloat the JSON; such strains simply omit covered_intervals
+    # and the report falls back to the per-bin-max union for them. Sized to
+    # comfortably hold even a large, fragmented bacterial genome (e.g. a ~7 Mbp
+    # reference with tens of thousands of covered runs); pathological cases fall
+    # back rather than bloat the report.
+    _MAX_COVERED_INTERVAL_NUMS = 300000
+
     # ── Breadth histogram: always exactly 100 bins per strain ─────────────────
     # Pass 1 (inline, during the existing contig loop below): collect each
     # accession's covered_regions offset into a per-strain coordinate space so
@@ -3330,6 +3364,11 @@ def main():
                     'breaks':       _brk_bins,
                     'contig_names': _breadth_names_by_key.get(_skey, []),
                 }
+                # Compact covered runs (concatenated coords) so the report can
+                # compute an exact breadth union across a specimen's samples.
+                _ivals = _merge_covered_intervals(_breadth_regs_by_key[_skey])
+                if _ivals and len(_ivals) <= _MAX_COVERED_INTERVAL_NUMS:
+                    _breadth_bins_by_key[_skey]['covered_intervals'] = _ivals
 
     # Sort contigs by reads desc, cap at 100 per strain (prevent JSON bloat)
     for _skey in _contig_by_key:
@@ -3427,6 +3466,13 @@ def main():
                         'breaks':       _bbins['breaks'],
                         'contig_names': _bbins.get('contig_names', []),
                     }
+                    # Carry the compact covered runs through to the report so it
+                    # can compute an EXACT breadth union across a specimen's
+                    # samples (per-bin max is only a lower bound). Built in
+                    # pass 2 and size-capped there.
+                    _ci = _bbins.get('covered_intervals')
+                    if _ci:
+                        _strain['breadth_histogram']['covered_intervals'] = _ci
 
     # ── Resolve best cutoffs from thresholds JSON (if available) ──────────
     # Extract per-group best_threshold values so create_report.py can use

--- a/server.py
+++ b/server.py
@@ -1,0 +1,12 @@
+import http.server
+
+# Custom handler to add no-cache headers
+class NoCacheHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate')
+        self.send_header('Pragma', 'no-cache')
+        self.send_header('Expires', '0')
+        super().end_headers()
+
+if __name__ == '__main__':
+    http.server.test(HandlerClass=NoCacheHTTPRequestHandler, port=8000)


### PR DESCRIPTION
- Adding in help feature per tab that highlights sub-areas
- Adding grouping on sample into a single specimen. Higher/max values are chosen for shared organisms and total sums are operating as expected e.g. Sample A = 20 reads and Sample B = 10 reads total reads becomes 30 for the group. 
- Adding toggle and window feature for group info/metadata
- Merging some metadata features with map with groups