### PR TITLE
Vectorize symmetry operation after looping once in conflict_regions.py

### DIFF
--- a/bin/conflict_regions.py
+++ b/bin/conflict_regions.py
@@ -2473,9 +2473,6 @@ def build_organism_signatures_from_fastas_ani(
     org_siglist.sort(key=lambda x: x[0])
     return org_siglist, dict(stats)
 
-def _safe_ani(mh1, mh2):
-    res = mh1.containment_ani(mh2)
-    return float(res.ani) if res and res.ani is not None else 0.0
 def organism_ani_matrix_from_sigs(
     org_siglist: List[Tuple[str, SourmashSignature]],
     *,
@@ -2495,25 +2492,23 @@ def organism_ani_matrix_from_sigs(
 
     mat = pd.DataFrame(0.0, index=taxids, columns=taxids, dtype=float)
 
-    for i, t1 in enumerate(taxids):
+    for t1 in taxids:
         mh1 = mhs[t1]
-        for j, t2 in enumerate(taxids):
+        for t2 in taxids:
             if t1 == t2:
                 mat.at[t1, t2] = diagonal
                 continue
             mh2 = mhs[t2]
-            a12 = _safe_ani(mh1, mh2)
-            a21 = _safe_ani(mh2, mh1)
+            if (res := mh1.containment_ani(mh2)) and res.ani is not None:
+                mat.at[t1, t2] = float(res.ani)
+            # otherwise leave mat.at[t1, t2] as default value
 
-            if symmetrize == "min":
-                v = min(a12, a21)
-            elif symmetrize == "max":
-                v = max(a12, a21)
-            else:
-                v = 0.5 * (a12 + a21)
-
-            mat.at[t1, t2] = v
-
+    if symmetrize == "min":
+        return pd.DataFrame(np.minimum(mat.to_numpy(), mat.T.to_numpy()), index=mat.index, columns=mat.columns)
+    if symmetrize == "max":
+        return pd.DataFrame(np.maximum(mat.to_numpy(), mat.T.to_numpy()), index=mat.index, columns=mat.columns)
+    if symmetrize == "mean":
+        return (mat + mat.T) / 2
     return mat
 
 def finalize_proportional_removal(conflict_groups, bam_fs, fetch_reads_in_region, remove_mode='random', random_seed=None, dominance_protect_ratio: float = 3.0):


### PR DESCRIPTION
This halved execution time for `organism_ani_matrix_from_sigs`. Don't know about memory impact.

<!--
# jhuapl-bio/taxtriage pull request

Many thanks for contributing to jhuapl-bio/taxtriage!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/jhuapl-bio/taxtriage/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/jhuapl-bio/taxtriage/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the jhuapl-bio/taxtriage _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
___

Instead of building the symmetric matrix by applying the symmetrization function to each element, I applied a (vectorized) symmetrization operation to the asymmetric square matrix and its transpose. For good measure, I also inlined the former `_safe_ani(mh1, mh2)` function by using the [walrus operator](https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions). These changes more than halved the execution time of this function, with no noticeable impact to memory usage.

Let me know if you don't want the walrus operator in the code. I found nowhere else in the Python codebase that has a walrus operator.
